### PR TITLE
Sequence from disk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,15 +30,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,21 +79,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.86"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
-
-[[package]]
-name = "approx"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "async-compression"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,77 +113,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "bio"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8cbd545253762ecf9ef741f2c49f07c06a0ce4d041d74ee9c3f1ce0e2d5446e"
-dependencies = [
- "anyhow",
- "approx",
- "bio-types",
- "bit-set",
- "bv",
- "bytecount",
- "csv",
- "custom_derive",
- "editdistancek",
- "enum-map",
- "fxhash",
- "itertools",
- "itertools-num",
- "lazy_static",
- "multimap",
- "ndarray",
- "newtype_derive",
- "num-integer",
- "num-traits",
- "ordered-float",
- "petgraph",
- "rand",
- "regex",
- "serde",
- "serde_derive",
- "statrs",
- "strum",
- "strum_macros",
- "thiserror",
- "triple_accel",
- "vec_map",
-]
-
-[[package]]
-name = "bio-types"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cc7edd677651969cc262a8dfb870f0c2266c3ceeaf863d742982e39699ff460"
-dependencies = [
- "derive-new",
- "lazy_static",
- "regex",
- "strum_macros",
- "thiserror",
-]
-
-[[package]]
-name = "bit-set"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
-dependencies = [
- "bit-vec 0.8.0",
-]
-
-[[package]]
 name = "bit-vec"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2c54ff287cfc0a34f38a6b832ea1bd8e448a330b3e40a50859e6488bee07f22"
-
-[[package]]
-name = "bit-vec"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -233,28 +142,6 @@ dependencies = [
  "memchr",
  "serde",
 ]
-
-[[package]]
-name = "bv"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8834bb1d8ee5dc048ee3124f2c7c1afcc6bc9aed03f11e9dfd8c69470a5db340"
-dependencies = [
- "feature-probe",
- "serde",
-]
-
-[[package]]
-name = "bytecount"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
-
-[[package]]
-name = "bytemuck"
-version = "1.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "102087e286b4677862ea56cf8fc58bb2cdfa8725c40ffb80fe3a008eb7f2fc83"
 
 [[package]]
 name = "byteorder"
@@ -391,44 +278,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "csv"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "custom_derive"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
-
-[[package]]
-name = "derive-new"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d150dea618e920167e5973d70ae6ece4385b7164e0d799fe7c122dd0a5d912ad"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -436,38 +285,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
-]
-
-[[package]]
-name = "editdistancek"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e02df23d5b1c6f9e69fa603b890378123b93073df998a21e6e33b9db0a32613"
-
-[[package]]
-name = "either"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
-
-[[package]]
-name = "enum-map"
-version = "2.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
-dependencies = [
- "enum-map-derive",
-]
-
-[[package]]
-name = "enum-map-derive"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -487,12 +304,6 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
-
-[[package]]
-name = "feature-probe"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
 
 [[package]]
 name = "fixedbitset"
@@ -576,19 +387,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "gen"
 version = "0.1.0"
 dependencies = [
- "bio",
  "clap",
  "include_dir",
  "noodles",
@@ -606,17 +407,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
 ]
 
 [[package]]
@@ -683,36 +473,6 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools-num"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a872a22f9e6f7521ca557660adb96dd830e54f0f490fa115bb55dd69d38b27e7"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "itoa"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lexical-core"
@@ -785,12 +545,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
-name = "libm"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
-
-[[package]]
 name = "libsqlite3-sys"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -819,16 +573,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matrixmultiply"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9380b911e3e96d10c1f415da0876389aaf1b56759054eeb0de7df940c456ba1a"
-dependencies = [
- "autocfg",
- "rawpointer",
-]
-
-[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -854,66 +598,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "multimap"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "nalgebra"
-version = "0.32.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5c17de023a86f59ed79891b2e5d5a94c705dbe904a5b5c9c952ea6221b03e4"
-dependencies = [
- "approx",
- "matrixmultiply",
- "nalgebra-macros",
- "num-complex",
- "num-rational",
- "num-traits",
- "rand",
- "rand_distr",
- "simba",
- "typenum",
-]
-
-[[package]]
-name = "nalgebra-macros"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "ndarray"
-version = "0.15.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
-dependencies = [
- "matrixmultiply",
- "num-complex",
- "num-integer",
- "num-traits",
- "rawpointer",
-]
-
-[[package]]
-name = "newtype_derive"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac8cd24d9f185bb7223958d8c1ff7a961b74b1953fd05dba7cc568a63b3861ec"
-dependencies = [
- "rustc_version",
-]
-
-[[package]]
 name = "noodles"
 version = "0.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,6 +606,7 @@ dependencies = [
  "noodles-bam",
  "noodles-bcf",
  "noodles-bgzf",
+ "noodles-core",
  "noodles-cram",
  "noodles-csi",
  "noodles-fasta",
@@ -938,7 +623,7 @@ version = "0.65.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "406d4768f21c73e3075c0c0d77a5b21bc8b8169c8f0963122607cc410427b727"
 dependencies = [
- "bit-vec 0.7.0",
+ "bit-vec",
  "bstr",
  "byteorder",
  "bytes",
@@ -1023,7 +708,7 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4bc8001c54f1d8e47e1ac6041a5f27edc99b68bacea3fade9c89059de285aea"
 dependencies = [
- "bit-vec 0.7.0",
+ "bit-vec",
  "byteorder",
  "indexmap",
  "noodles-bgzf",
@@ -1095,7 +780,7 @@ version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "545e16e229b7f8734b0a2a36bd4c98a5b70128663b16b5201ddadc0d09c28d4a"
 dependencies = [
- "bit-vec 0.7.0",
+ "bit-vec",
  "byteorder",
  "indexmap",
  "noodles-bgzf",
@@ -1123,44 +808,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
- "libm",
-]
-
-[[package]]
 name = "object"
 version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1174,21 +821,6 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
-name = "ordered-float"
-version = "4.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a91171844676f8c7990ce64959210cd2eaef32c2612c50f9fae9f8aaa6065a6"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -1225,15 +857,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1250,81 +873,6 @@ checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom",
-]
-
-[[package]]
-name = "rand_distr"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
-dependencies = [
- "num-traits",
- "rand",
-]
-
-[[package]]
-name = "rawpointer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
-
-[[package]]
-name = "regex"
-version = "1.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "rusqlite"
@@ -1358,42 +906,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
-name = "rustc_version"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
-dependencies = [
- "semver",
-]
-
-[[package]]
-name = "rustversion"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
-
-[[package]]
-name = "ryu"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
-
-[[package]]
-name = "safe_arch"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3460605018fdc9612bce72735cba0d27efbcd9904780d44c7e3a9948f96148a"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
-name = "semver"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
-
-[[package]]
 name = "serde"
 version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1425,19 +937,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simba"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061507c94fc6ab4ba1c9a0305018408e312e17c041eb63bef8aa726fa33aceae"
-dependencies = [
- "approx",
- "num-complex",
- "num-traits",
- "paste",
- "wide",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1459,41 +958,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "statrs"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f697a07e4606a0a25c044de247e583a330dbb1731d11bc7350b81f48ad567255"
-dependencies = [
- "approx",
- "nalgebra",
- "num-traits",
- "rand",
-]
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
-]
 
 [[package]]
 name = "syn"
@@ -1504,26 +972,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1551,12 +999,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "triple_accel"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22048bc95dfb2ffd05b1ff9a756290a009224b60b2f0e7525faeee7603851e63"
-
-[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1581,35 +1023,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "wide"
-version = "0.7.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "901e8597c777fa042e9e245bd56c0dc4418c5db3f845b6ff94fbac732c6a0692"
-dependencies = [
- "bytemuck",
- "safe_arch",
-]
 
 [[package]]
 name = "windows-sys"
@@ -1699,7 +1116,6 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "byteorder",
  "zerocopy-derive",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bio = "2.0.0"
 clap = { version = "4.5.8", features = ["derive"] }
 include_dir = "0.7.4"
 rusqlite = { version = "0.31.0", features = ["bundled", "array"] }
 rusqlite_migration = { version = "1.2.0" , features = ["from-directory"]}
 sha2 = "0.10.8"
-noodles = { version = "0.78.0", features = ["vcf", "fasta", "async"] }
+noodles = { version = "0.78.0", features = ["core", "vcf", "fasta", "async"] }
 petgraph = "0.6.5"

--- a/migrations/01-initial/up.sql
+++ b/migrations/01-initial/up.sql
@@ -10,6 +10,7 @@ CREATE TABLE sequence (
   hash TEXT PRIMARY KEY NOT NULL,
   sequence_type TEXT NOT NULL,
   sequence TEXT,
+  file_path TEXT,
   "length" INTEGER NOT NULL
 );
 

--- a/migrations/01-initial/up.sql
+++ b/migrations/01-initial/up.sql
@@ -10,6 +10,7 @@ CREATE TABLE sequence (
   hash TEXT PRIMARY KEY NOT NULL,
   sequence_type TEXT NOT NULL,
   sequence TEXT,
+  name TEXT,
   file_path TEXT,
   "length" INTEGER NOT NULL
 );

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use clap::{Parser, Subcommand};
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::path::PathBuf;
+use std::{io, str};
 
 use gen::migrations::run_migrations;
 use gen::models::{self, block::Block, edge::Edge, path::Path, sequence::Sequence, BlockGroup};
@@ -15,7 +16,6 @@ use noodles::vcf::variant::record::samples::{Sample, Series};
 use noodles::vcf::variant::record::{AlternateBases, ReferenceBases, Samples};
 use noodles::vcf::variant::Record;
 use rusqlite::{types::Value as SQLValue, Connection};
-use std::io;
 
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
@@ -73,7 +73,9 @@ fn import_fasta(fasta: &String, name: &str, shallow: bool, conn: &mut Connection
 
         for result in reader.records() {
             let record = result.expect("Error during fasta record parsing");
-            let sequence = String::from_utf8(record.sequence().as_ref().to_vec()).unwrap();
+            let sequence = str::from_utf8(record.sequence().as_ref())
+                .unwrap()
+                .to_string();
             let name = String::from_utf8(record.name().to_vec()).unwrap();
             let sequence_length = record.sequence().len() as i32;
             let seq_hash = Sequence::create(

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,9 +82,10 @@ fn import_fasta(fasta: &String, name: &str, shallow: bool, conn: &mut Connection
                 conn,
                 &Sequence {
                     sequence_type: "DNA".to_string(),
-                    sequence,
+                    sequence: if shallow { "".to_string() } else { sequence },
                     name: name.clone(),
                     file_path: fasta.clone(),
+                    length: sequence_length,
                     external_sequence: !shallow,
                     ..Default::default()
                 },

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,6 +83,7 @@ fn import_fasta(fasta: &String, name: &str, shallow: bool, conn: &mut Connection
                 &Sequence {
                     sequence_type: "DNA".to_string(),
                     sequence,
+                    name: name.clone(),
                     file_path: fasta.clone(),
                     external_sequence: !shallow,
                     ..Default::default()

--- a/src/models.rs
+++ b/src/models.rs
@@ -416,9 +416,9 @@ impl BlockGroup {
 
             let (contains_start, contains_end, overlap) =
                 get_overlap(path_start, path_end, start, end);
-            println!(
-                "{path_start} {path_end} {start} {end} {contains_start} {contains_end} {overlap}"
-            );
+            // println!(
+            //     "{path_start} {path_end} {start} {end} {contains_start} {contains_end} {overlap}"
+            // );
 
             if contains_start && contains_end {
                 // our range is fully contained w/in the block
@@ -593,10 +593,38 @@ mod tests {
     }
 
     fn setup_block_group(conn: &Connection) -> (i32, i32) {
-        let a_seq_hash = Sequence::create(conn, "DNA", "AAAAAAAAAA", true);
-        let t_seq_hash = Sequence::create(conn, "DNA", "TTTTTTTTTT", true);
-        let c_seq_hash = Sequence::create(conn, "DNA", "CCCCCCCCCC", true);
-        let g_seq_hash = Sequence::create(conn, "DNA", "GGGGGGGGGG", true);
+        let a_seq_hash = Sequence::create(
+            conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "AAAAAAAAAA".to_string(),
+                ..Default::default()
+            },
+        );
+        let t_seq_hash = Sequence::create(
+            conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "TTTTTTTTTT".to_string(),
+                ..Default::default()
+            },
+        );
+        let c_seq_hash = Sequence::create(
+            conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "CCCCCCCCCC".to_string(),
+                ..Default::default()
+            },
+        );
+        let g_seq_hash = Sequence::create(
+            conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "GGGGGGGGGG".to_string(),
+                ..Default::default()
+            },
+        );
         let _collection = Collection::create(conn, "test");
         let block_group = BlockGroup::create(conn, "test", None, "hg19");
         let a_block = Block::create(conn, &a_seq_hash, block_group.id, 0, 10, "+");
@@ -621,7 +649,14 @@ mod tests {
     fn insert_and_deletion() {
         let mut conn = get_connection();
         let (block_group_id, path_id) = setup_block_group(&conn);
-        let insert_sequence = Sequence::create(&conn, "DNA", "NNNN", true);
+        let insert_sequence = Sequence::create(
+            &conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "NNNN".to_string(),
+                ..Default::default()
+            },
+        );
         let insert = Block::create(&conn, &insert_sequence, block_group_id, 0, 4, "+");
         BlockGroup::insert_change(&mut conn, path_id, 7, 15, &insert, 1, 0);
 
@@ -635,7 +670,14 @@ mod tests {
         );
 
         // TODO: should handle this w/ edges instead of a block, maybe this is ok though.
-        let deletion_sequence = Sequence::create(&conn, "DNA", "", true);
+        let deletion_sequence = Sequence::create(
+            &conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "".to_string(),
+                ..Default::default()
+            },
+        );
         let deletion = Block::create(&conn, &deletion_sequence, block_group_id, 0, 0, "+");
 
         // take out an entire block.
@@ -656,7 +698,14 @@ mod tests {
     fn simple_insert() {
         let mut conn = get_connection();
         let (block_group_id, path_id) = setup_block_group(&conn);
-        let insert_sequence = Sequence::create(&conn, "DNA", "NNNN", true);
+        let insert_sequence = Sequence::create(
+            &conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "NNNN".to_string(),
+                ..Default::default()
+            },
+        );
         let insert = Block::create(&conn, &insert_sequence, block_group_id, 0, 4, "+");
         BlockGroup::insert_change(&mut conn, path_id, 7, 15, &insert, 1, 0);
 
@@ -674,7 +723,14 @@ mod tests {
     fn insert_on_block_boundary_middle() {
         let mut conn = get_connection();
         let (block_group_id, path_id) = setup_block_group(&conn);
-        let insert_sequence = Sequence::create(&conn, "DNA", "NNNN", true);
+        let insert_sequence = Sequence::create(
+            &conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "NNNN".to_string(),
+                ..Default::default()
+            },
+        );
         let insert = Block::create(&conn, &insert_sequence, block_group_id, 0, 4, "+");
         BlockGroup::insert_change(&mut conn, path_id, 15, 15, &insert, 1, 0);
 
@@ -692,7 +748,14 @@ mod tests {
     fn insert_within_block() {
         let mut conn = get_connection();
         let (block_group_id, path_id) = setup_block_group(&conn);
-        let insert_sequence = Sequence::create(&conn, "DNA", "NNNN", true);
+        let insert_sequence = Sequence::create(
+            &conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "NNNN".to_string(),
+                ..Default::default()
+            },
+        );
         let insert = Block::create(&conn, &insert_sequence, block_group_id, 0, 4, "+");
         BlockGroup::insert_change(&mut conn, path_id, 12, 17, &insert, 1, 0);
 
@@ -710,7 +773,14 @@ mod tests {
     fn insert_on_block_boundary_start() {
         let mut conn = get_connection();
         let (block_group_id, path_id) = setup_block_group(&conn);
-        let insert_sequence = Sequence::create(&conn, "DNA", "NNNN", true);
+        let insert_sequence = Sequence::create(
+            &conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "NNNN".to_string(),
+                ..Default::default()
+            },
+        );
         let insert = Block::create(&conn, &insert_sequence, block_group_id, 0, 4, "+");
         BlockGroup::insert_change(&mut conn, path_id, 10, 10, &insert, 1, 0);
 
@@ -728,7 +798,14 @@ mod tests {
     fn insert_on_block_boundary_end() {
         let mut conn = get_connection();
         let (block_group_id, path_id) = setup_block_group(&conn);
-        let insert_sequence = Sequence::create(&conn, "DNA", "NNNN", true);
+        let insert_sequence = Sequence::create(
+            &conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "NNNN".to_string(),
+                ..Default::default()
+            },
+        );
         let insert = Block::create(&conn, &insert_sequence, block_group_id, 0, 4, "+");
         BlockGroup::insert_change(&mut conn, path_id, 9, 9, &insert, 1, 0);
 
@@ -746,7 +823,14 @@ mod tests {
     fn insert_across_entire_block_boundary() {
         let mut conn = get_connection();
         let (block_group_id, path_id) = setup_block_group(&conn);
-        let insert_sequence = Sequence::create(&conn, "DNA", "NNNN", true);
+        let insert_sequence = Sequence::create(
+            &conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "NNNN".to_string(),
+                ..Default::default()
+            },
+        );
         let insert = Block::create(&conn, &insert_sequence, block_group_id, 0, 4, "+");
         BlockGroup::insert_change(&mut conn, path_id, 10, 20, &insert, 1, 0);
 
@@ -764,7 +848,14 @@ mod tests {
     fn insert_across_two_blocks() {
         let mut conn = get_connection();
         let (block_group_id, path_id) = setup_block_group(&conn);
-        let insert_sequence = Sequence::create(&conn, "DNA", "NNNN", true);
+        let insert_sequence = Sequence::create(
+            &conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "NNNN".to_string(),
+                ..Default::default()
+            },
+        );
         let insert = Block::create(&conn, &insert_sequence, block_group_id, 0, 4, "+");
         BlockGroup::insert_change(&mut conn, path_id, 15, 25, &insert, 1, 0);
 
@@ -782,7 +873,14 @@ mod tests {
     fn insert_spanning_blocks() {
         let mut conn = get_connection();
         let (block_group_id, path_id) = setup_block_group(&conn);
-        let insert_sequence = Sequence::create(&conn, "DNA", "NNNN", true);
+        let insert_sequence = Sequence::create(
+            &conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "NNNN".to_string(),
+                ..Default::default()
+            },
+        );
         let insert = Block::create(&conn, &insert_sequence, block_group_id, 0, 4, "+");
         BlockGroup::insert_change(&mut conn, path_id, 5, 35, &insert, 1, 0);
 
@@ -800,7 +898,14 @@ mod tests {
     fn simple_deletion() {
         let mut conn = get_connection();
         let (block_group_id, path_id) = setup_block_group(&conn);
-        let deletion_sequence = Sequence::create(&conn, "DNA", "", true);
+        let deletion_sequence = Sequence::create(
+            &conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "".to_string(),
+                ..Default::default()
+            },
+        );
         let deletion = Block::create(&conn, &deletion_sequence, block_group_id, 0, 0, "+");
 
         // take out an entire block.
@@ -819,7 +924,14 @@ mod tests {
     fn doesnt_apply_same_insert_twice() {
         let mut conn = get_connection();
         let (block_group_id, path_id) = setup_block_group(&conn);
-        let insert_sequence = Sequence::create(&conn, "DNA", "NNNN", true);
+        let insert_sequence = Sequence::create(
+            &conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "NNNN".to_string(),
+                ..Default::default()
+            },
+        );
         let insert = Block::create(&conn, &insert_sequence, block_group_id, 0, 4, "+");
         BlockGroup::insert_change(&mut conn, path_id, 7, 15, &insert, 1, 0);
 

--- a/src/models/block.rs
+++ b/src/models/block.rs
@@ -649,10 +649,16 @@ mod tests {
             ("ATCGATCGATCG".to_string(), "+".to_string())
         );
 
-        let block = Block::create(conn, &seq, bg.id, 0, 9, "+");
+        let block = Block::create(conn, &seq, bg.id, 3, 9, "+");
         assert_eq!(
             Block::get_sequence(conn, block.id),
-            ("ATCGATCGA".to_string(), "+".to_string())
+            ("GATCGA".to_string(), "+".to_string())
+        );
+
+        let block = Block::create(conn, &seq, bg.id, 3, 9, "-");
+        assert_eq!(
+            Block::get_sequence(conn, block.id),
+            ("GATCGA".to_string(), "-".to_string())
         );
     }
 }

--- a/src/models/block.rs
+++ b/src/models/block.rs
@@ -3,7 +3,7 @@ use crate::models::path::PathBlock;
 use noodles::core::Position;
 use noodles::fasta;
 use rusqlite::{params_from_iter, types::Value, Connection};
-use std::fs;
+use std::{fs, str};
 
 #[derive(Clone, Debug)]
 pub struct Block {
@@ -284,15 +284,15 @@ impl Block {
                 let mut reader = fasta::io::indexed_reader::Builder::default()
                     .build_from_path(external_path)
                     .unwrap();
-                sequence = String::from_utf8(
+                sequence = str::from_utf8(
                     reader
                         .query(&format!("{name}:{start}-{end}").parse().unwrap())
                         .unwrap()
                         .sequence()
-                        .as_ref()
-                        .to_vec(),
+                        .as_ref(),
                 )
-                .unwrap();
+                .unwrap()
+                .to_string();
             } else {
                 let mut reader = fasta::io::reader::Builder
                     .build_from_path(external_path)
@@ -300,7 +300,7 @@ impl Block {
                 for result in reader.records() {
                     let record = result.unwrap();
                     if String::from_utf8(record.name().to_vec()).unwrap() == name {
-                        sequence = String::from_utf8(
+                        sequence = str::from_utf8(
                             record
                                 .sequence()
                                 .slice(
@@ -308,10 +308,10 @@ impl Block {
                                         ..=Position::try_from(end as usize).unwrap(),
                                 )
                                 .unwrap()
-                                .as_ref()
-                                .to_vec(),
+                                .as_ref(),
                         )
-                        .unwrap();
+                        .unwrap()
+                        .to_string();
                         break;
                     }
                 }

--- a/src/models/block.rs
+++ b/src/models/block.rs
@@ -282,13 +282,41 @@ mod tests {
         let conn = &mut get_connection();
         Collection::create(conn, "test collection");
         let block_group = BlockGroup::create(conn, "test collection", None, "test block group");
-        let sequence1_hash = Sequence::create(conn, "DNA", "ATCGATCG", true);
+        let sequence1_hash = Sequence::create(
+            conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "ATCGATCG".to_string(),
+                ..Default::default()
+            },
+        );
         let block1 = Block::create(conn, &sequence1_hash, block_group.id, 0, 8, "+");
-        let sequence2_hash = Sequence::create(conn, "DNA", "AAAAAAAA", true);
+        let sequence2_hash = Sequence::create(
+            conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "AAAAAAAA".to_string(),
+                ..Default::default()
+            },
+        );
         let block2 = Block::create(conn, &sequence2_hash, block_group.id, 1, 8, "+");
-        let sequence3_hash = Sequence::create(conn, "DNA", "CCCCCCCC", true);
+        let sequence3_hash = Sequence::create(
+            conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "CCCCCCCC".to_string(),
+                ..Default::default()
+            },
+        );
         let block3 = Block::create(conn, &sequence3_hash, block_group.id, 1, 8, "+");
-        let sequence4_hash = Sequence::create(conn, "DNA", "GGGGGGGG", true);
+        let sequence4_hash = Sequence::create(
+            conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "GGGGGGGG".to_string(),
+                ..Default::default()
+            },
+        );
         let block4 = Block::create(conn, &sequence4_hash, block_group.id, 1, 8, "+");
         let edge1 = Edge::create(conn, Some(block1.id), Some(block3.id), 0, 0);
         let edge2 = Edge::create(conn, Some(block2.id), Some(block3.id), 0, 0);
@@ -311,9 +339,23 @@ mod tests {
         let conn = &mut get_connection();
         Collection::create(conn, "test collection");
         let block_group = BlockGroup::create(conn, "test collection", None, "test block group");
-        let sequence1_hash = Sequence::create(conn, "DNA", "ATCGATCG", true);
+        let sequence1_hash = Sequence::create(
+            conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "ATCGATCG".to_string(),
+                ..Default::default()
+            },
+        );
         let block1 = Block::create(conn, &sequence1_hash, block_group.id, 0, 8, "+");
-        let sequence2_hash = Sequence::create(conn, "DNA", "AAAAAAAA", true);
+        let sequence2_hash = Sequence::create(
+            conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "AAAAAAAA".to_string(),
+                ..Default::default()
+            },
+        );
         let block2 = Block::create(conn, &sequence2_hash, block_group.id, 1, 8, "+");
         Edge::create(conn, Some(block1.id), Some(block2.id), 0, 0);
 
@@ -326,13 +368,41 @@ mod tests {
         let conn = &mut get_connection();
         Collection::create(conn, "test collection");
         let block_group = BlockGroup::create(conn, "test collection", None, "test block group");
-        let sequence1_hash = Sequence::create(conn, "DNA", "ATCGATCG", true);
+        let sequence1_hash = Sequence::create(
+            conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "ATCGATCG".to_string(),
+                ..Default::default()
+            },
+        );
         let block1 = Block::create(conn, &sequence1_hash, block_group.id, 0, 8, "+");
-        let sequence2_hash = Sequence::create(conn, "DNA", "AAAAAAAA", true);
+        let sequence2_hash = Sequence::create(
+            conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "AAAAAAAA".to_string(),
+                ..Default::default()
+            },
+        );
         let block2 = Block::create(conn, &sequence2_hash, block_group.id, 1, 8, "+");
-        let sequence3_hash = Sequence::create(conn, "DNA", "CCCCCCCC", true);
+        let sequence3_hash = Sequence::create(
+            conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "CCCCCCCC".to_string(),
+                ..Default::default()
+            },
+        );
         let block3 = Block::create(conn, &sequence3_hash, block_group.id, 1, 8, "+");
-        let sequence4_hash = Sequence::create(conn, "DNA", "GGGGGGGG", true);
+        let sequence4_hash = Sequence::create(
+            conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "GGGGGGGG".to_string(),
+                ..Default::default()
+            },
+        );
         let block4 = Block::create(conn, &sequence4_hash, block_group.id, 1, 8, "+");
         Edge::create(conn, Some(block1.id), Some(block2.id), 0, 0);
         let edge1 = Edge::create(conn, Some(block2.id), Some(block3.id), 0, 0);
@@ -355,9 +425,23 @@ mod tests {
         let conn = &mut get_connection();
         Collection::create(conn, "test collection");
         let block_group = BlockGroup::create(conn, "test collection", None, "test block group");
-        let sequence1_hash = Sequence::create(conn, "DNA", "ATCGATCG", true);
+        let sequence1_hash = Sequence::create(
+            conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "ATCGATCG".to_string(),
+                ..Default::default()
+            },
+        );
         let block1 = Block::create(conn, &sequence1_hash, block_group.id, 0, 8, "+");
-        let sequence2_hash = Sequence::create(conn, "DNA", "AAAAAAAA", true);
+        let sequence2_hash = Sequence::create(
+            conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "AAAAAAAA".to_string(),
+                ..Default::default()
+            },
+        );
         let block2 = Block::create(conn, &sequence2_hash, block_group.id, 1, 8, "+");
         Edge::create(conn, Some(block1.id), Some(block2.id), 0, 0);
 
@@ -370,13 +454,41 @@ mod tests {
         let conn = &mut get_connection();
         Collection::create(conn, "test collection");
         let block_group = BlockGroup::create(conn, "test collection", None, "test block group");
-        let sequence1_hash = Sequence::create(conn, "DNA", "ATCGATCG", true);
+        let sequence1_hash = Sequence::create(
+            conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "ATCGATCG".to_string(),
+                ..Default::default()
+            },
+        );
         let block1 = Block::create(conn, &sequence1_hash, block_group.id, 0, 8, "+");
-        let sequence2_hash = Sequence::create(conn, "DNA", "AAAAAAAA", true);
+        let sequence2_hash = Sequence::create(
+            conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "AAAAAAAA".to_string(),
+                ..Default::default()
+            },
+        );
         let block2 = Block::create(conn, &sequence2_hash, block_group.id, 1, 8, "+");
-        let sequence3_hash = Sequence::create(conn, "DNA", "CCCCCCCC", true);
+        let sequence3_hash = Sequence::create(
+            conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "CCCCCCCC".to_string(),
+                ..Default::default()
+            },
+        );
         let block3 = Block::create(conn, &sequence3_hash, block_group.id, 1, 8, "+");
-        let sequence4_hash = Sequence::create(conn, "DNA", "GGGGGGGG", true);
+        let sequence4_hash = Sequence::create(
+            conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "GGGGGGGG".to_string(),
+                ..Default::default()
+            },
+        );
         let block4 = Block::create(conn, &sequence4_hash, block_group.id, 1, 8, "+");
         let edge1 = Edge::create(conn, Some(block1.id), Some(block3.id), 0, 0);
         let edge2 = Edge::create(conn, Some(block2.id), Some(block3.id), 0, 0);
@@ -408,7 +520,14 @@ mod tests {
         let conn = &mut get_connection();
         Collection::create(conn, "test collection");
         let block_group = BlockGroup::create(conn, "test collection", None, "test block group");
-        let sequence1_hash = Sequence::create(conn, "DNA", "ATCGATCG", true);
+        let sequence1_hash = Sequence::create(
+            conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "ATCGATCG".to_string(),
+                ..Default::default()
+            },
+        );
         let block1 = Block::create(conn, &sequence1_hash, block_group.id, 0, 8, "+");
         let result = Block::split(conn, &block1, -1, 0, 0);
         assert!(result.is_none());
@@ -422,7 +541,14 @@ mod tests {
     fn get_sequence() {
         let conn = &mut get_connection();
         let sequence = "AAATTTCCCGGG".to_string();
-        let seq = Sequence::create(conn, "DNA", &sequence, true);
+        let seq = Sequence::create(
+            conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: sequence.clone(),
+                ..Default::default()
+            },
+        );
         Collection::create(conn, "test collection");
         let bg = BlockGroup::create(conn, "test collection", None, "test");
         let block = Block::create(conn, &seq, bg.id, 0, 12, "+");

--- a/src/models/path.rs
+++ b/src/models/path.rs
@@ -290,13 +290,41 @@ mod tests {
         let conn = &mut get_connection();
         Collection::create(conn, "test collection");
         let block_group = BlockGroup::create(conn, "test collection", None, "test block group");
-        let sequence1_hash = Sequence::create(conn, "DNA", "ATCGATCG", true);
+        let sequence1_hash = Sequence::create(
+            conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "ATCGATCG".to_string(),
+                ..Default::default()
+            },
+        );
         let block1 = Block::create(conn, &sequence1_hash, block_group.id, 0, 8, "+");
-        let sequence2_hash = Sequence::create(conn, "DNA", "AAAAAAAA", true);
+        let sequence2_hash = Sequence::create(
+            conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "AAAAAAAA".to_string(),
+                ..Default::default()
+            },
+        );
         let block2 = Block::create(conn, &sequence2_hash, block_group.id, 1, 8, "+");
-        let sequence3_hash = Sequence::create(conn, "DNA", "CCCCCCCC", true);
+        let sequence3_hash = Sequence::create(
+            conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "CCCCCCCC".to_string(),
+                ..Default::default()
+            },
+        );
         let block3 = Block::create(conn, &sequence3_hash, block_group.id, 1, 8, "+");
-        let sequence4_hash = Sequence::create(conn, "DNA", "GGGGGGGG", true);
+        let sequence4_hash = Sequence::create(
+            conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "GGGGGGGG".to_string(),
+                ..Default::default()
+            },
+        );
         let block4 = Block::create(conn, &sequence4_hash, block_group.id, 1, 8, "+");
         Edge::create(conn, Some(block1.id), Some(block2.id), 0, 0);
         Edge::create(conn, Some(block2.id), Some(block3.id), 0, 0);
@@ -316,13 +344,41 @@ mod tests {
         let conn = &mut get_connection();
         Collection::create(conn, "test collection");
         let block_group = BlockGroup::create(conn, "test collection", None, "test block group");
-        let sequence1_hash = Sequence::create(conn, "DNA", "ATCGATCG", true);
+        let sequence1_hash = Sequence::create(
+            conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "ATCGATCG".to_string(),
+                ..Default::default()
+            },
+        );
         let block1 = Block::create(conn, &sequence1_hash, block_group.id, 0, 8, "-");
-        let sequence2_hash = Sequence::create(conn, "DNA", "AAAAAAAA", true);
+        let sequence2_hash = Sequence::create(
+            conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "AAAAAAAA".to_string(),
+                ..Default::default()
+            },
+        );
         let block2 = Block::create(conn, &sequence2_hash, block_group.id, 1, 8, "-");
-        let sequence3_hash = Sequence::create(conn, "DNA", "CCCCCCCC", true);
+        let sequence3_hash = Sequence::create(
+            conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "CCCCCCCC".to_string(),
+                ..Default::default()
+            },
+        );
         let block3 = Block::create(conn, &sequence3_hash, block_group.id, 1, 8, "-");
-        let sequence4_hash = Sequence::create(conn, "DNA", "GGGGGGGG", true);
+        let sequence4_hash = Sequence::create(
+            conn,
+            &Sequence {
+                sequence_type: "DNA".to_string(),
+                sequence: "GGGGGGGG".to_string(),
+                ..Default::default()
+            },
+        );
         let block4 = Block::create(conn, &sequence4_hash, block_group.id, 1, 8, "-");
         Edge::create(conn, Some(block1.id), Some(block2.id), 0, 0);
         Edge::create(conn, Some(block2.id), Some(block3.id), 0, 0);

--- a/src/models/sequence.rs
+++ b/src/models/sequence.rs
@@ -19,7 +19,11 @@ pub struct Sequence {
 impl Sequence {
     pub fn create(conn: &Connection, sequence: &Sequence) -> String {
         let mut hasher = Sha256::new();
-        let sequence_length = &sequence.sequence.len();
+        let sequence_length = if sequence.length == 0 {
+            sequence.sequence.len() as u32
+        } else {
+            sequence.length as u32
+        };
         hasher.update(&sequence.sequence_type);
         hasher.update(";");
         hasher.update(&sequence.sequence);
@@ -49,7 +53,7 @@ impl Sequence {
                         Value::from(sequence.sequence.clone()),
                         Value::from(sequence.name.clone()),
                         Value::from(sequence.file_path.clone()),
-                        Value::from(*sequence_length as u32),
+                        Value::from(sequence_length),
                     ),
                     |row| row.get(0),
                 )


### PR DESCRIPTION
Support storing sequences on disk instead of in db.

I removed the bio crate in favor of noodles as we are extensively using that elsewhere. I tried a new pattern for making it simpler to expand the Sequence model in the future. I know we discussed the builder/default pattern, and one thing I think may point to the builder being better is it will have fewer copies and less use of to_string.