### PR TITLE
Support sequences stored on disk

### DIFF
--- a/migrations/01-initial/up.sql
+++ b/migrations/01-initial/up.sql
@@ -10,7 +10,9 @@ CREATE TABLE sequence (
   hash TEXT PRIMARY KEY NOT NULL,
   sequence_type TEXT NOT NULL,
   sequence TEXT NOT NULL,
-  "length" INTEGER NOT NULL
+  name TEXT NOT NULL,
+  file_path TEXT NOT NULL,
+  length INTEGER NOT NULL
 );
 
 CREATE TABLE block_group (
@@ -80,4 +82,4 @@ CREATE TABLE block_group_edges (
 );
 CREATE UNIQUE INDEX block_group_edges_uidx ON block_group_edges(block_group_id, edge_id);
 
-INSERT INTO sequence (hash, sequence_type, sequence, "length") values ("start-node-yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy", "OTHER", "start-node-yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy", 64), ("end-node-zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz", "OTHER", "end-node-zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz", 64);
+INSERT INTO sequence (hash, sequence_type, sequence, name, file_path, "length") values ("start-node-yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy", "OTHER", "start-node-yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy", "", "", 64), ("end-node-zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz", "OTHER", "end-node-zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz", "", "", 64);

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,13 +87,13 @@ fn import_fasta(fasta: &String, name: &str, shallow: bool, conn: &mut Connection
             let name = String::from_utf8(record.name().to_vec()).unwrap();
             let sequence_length = record.sequence().len() as i32;
             let seq_hash = if shallow {
-                NewSequence::new()
+                Sequence::new()
                     .sequence_type("DNA")
                     .name(&name)
                     .file_path(fasta)
                     .save(conn)
             } else {
-                NewSequence::new()
+                Sequence::new()
                     .sequence_type("DNA")
                     .sequence(&sequence)
                     .save(conn)
@@ -180,7 +180,7 @@ fn update_with_vcf(
                             Phasing::Unphased => 0,
                         };
                         // TODO: new sequence may not be real and be <DEL> or some sort. Handle these.
-                        let new_sequence_hash = NewSequence::new()
+                        let new_sequence_hash = Sequence::new()
                             .sequence_type("DNA")
                             .sequence(alt_seq)
                             .save(conn);
@@ -239,7 +239,7 @@ fn update_with_vcf(
                                 if allele != 0 {
                                     let alt_seq = alt_alleles[allele - 1];
                                     // TODO: new sequence may not be real and be <DEL> or some sort. Handle these.
-                                    let new_sequence_hash = NewSequence::new()
+                                    let new_sequence_hash = Sequence::new()
                                         .sequence_type("DNA")
                                         .sequence(alt_seq)
                                         .save(conn);

--- a/src/models/block_group.rs
+++ b/src/models/block_group.rs
@@ -217,7 +217,7 @@ impl BlockGroup {
                 blocks.push(GroupBlock {
                     id: block_index,
                     sequence_hash: hash.clone(),
-                    sequence: sequence.sequence.clone(),
+                    sequence: sequence.get_sequence(None, None),
                     start: 0,
                     end: sequence.length,
                 });
@@ -579,7 +579,7 @@ mod tests {
         let deletion = NewBlock {
             id: 0,
             sequence: deletion_sequence.clone(),
-            block_sequence: deletion_sequence.sequence.clone(),
+            block_sequence: deletion_sequence.get_sequence(None, None),
             sequence_start: 0,
             sequence_end: 0,
             path_start: 19,
@@ -862,7 +862,7 @@ mod tests {
         let deletion = NewBlock {
             id: 0,
             sequence: deletion_sequence.clone(),
-            block_sequence: deletion_sequence.sequence.clone(),
+            block_sequence: deletion_sequence.get_sequence(None, None),
             sequence_start: 0,
             sequence_end: 0,
             path_start: 19,

--- a/src/models/block_group.rs
+++ b/src/models/block_group.rs
@@ -176,7 +176,7 @@ impl BlockGroup {
                 let first_edge = sorted_sequence_edges[0].clone();
                 let start = 0;
                 let end = first_edge.source_coordinate;
-                let block_sequence = sequence.sequence[start as usize..end as usize].to_string();
+                let block_sequence = sequence.get_sequence(start, end).to_string();
                 let first_block = GroupBlock {
                     id: block_index,
                     sequence_hash: hash.clone(),
@@ -189,8 +189,7 @@ impl BlockGroup {
                 for (into, out_of) in sorted_sequence_edges.clone().into_iter().tuple_windows() {
                     let start = into.target_coordinate;
                     let end = out_of.source_coordinate;
-                    let block_sequence =
-                        sequence.sequence[start as usize..end as usize].to_string();
+                    let block_sequence = sequence.get_sequence(start, end).to_string();
                     let block = GroupBlock {
                         id: block_index,
                         sequence_hash: hash.clone(),
@@ -204,7 +203,7 @@ impl BlockGroup {
                 let last_edge = &sorted_sequence_edges[sorted_sequence_edges.len() - 1];
                 let start = last_edge.target_coordinate;
                 let end = sequence.sequence.len() as i32;
-                let block_sequence = sequence.sequence[start as usize..end as usize].to_string();
+                let block_sequence = sequence.get_sequence(start, end).to_string();
                 let last_block = GroupBlock {
                     id: block_index,
                     sequence_hash: hash.clone(),
@@ -553,7 +552,7 @@ mod tests {
         let insert = NewBlock {
             id: 0,
             sequence: insert_sequence.clone(),
-            block_sequence: insert_sequence.sequence[0..4].to_string(),
+            block_sequence: insert_sequence.get_sequence(0, 4).to_string(),
             sequence_start: 0,
             sequence_end: 4,
             path_start: 7,
@@ -614,7 +613,7 @@ mod tests {
         let insert = NewBlock {
             id: 0,
             sequence: insert_sequence.clone(),
-            block_sequence: insert_sequence.sequence[0..4].to_string(),
+            block_sequence: insert_sequence.get_sequence(0, 4).to_string(),
             sequence_start: 0,
             sequence_end: 4,
             path_start: 7,
@@ -645,7 +644,7 @@ mod tests {
         let insert = NewBlock {
             id: 0,
             sequence: insert_sequence.clone(),
-            block_sequence: insert_sequence.sequence[0..4].to_string(),
+            block_sequence: insert_sequence.get_sequence(0, 4).to_string(),
             sequence_start: 0,
             sequence_end: 4,
             path_start: 15,
@@ -676,7 +675,7 @@ mod tests {
         let insert = NewBlock {
             id: 0,
             sequence: insert_sequence.clone(),
-            block_sequence: insert_sequence.sequence[0..4].to_string(),
+            block_sequence: insert_sequence.get_sequence(0, 4).to_string(),
             sequence_start: 0,
             sequence_end: 4,
             path_start: 12,
@@ -707,7 +706,7 @@ mod tests {
         let insert = NewBlock {
             id: 0,
             sequence: insert_sequence.clone(),
-            block_sequence: insert_sequence.sequence[0..4].to_string(),
+            block_sequence: insert_sequence.get_sequence(0, 4).to_string(),
             sequence_start: 0,
             sequence_end: 4,
             path_start: 10,
@@ -738,7 +737,7 @@ mod tests {
         let insert = NewBlock {
             id: 0,
             sequence: insert_sequence.clone(),
-            block_sequence: insert_sequence.sequence[0..4].to_string(),
+            block_sequence: insert_sequence.get_sequence(0, 4).to_string(),
             sequence_start: 0,
             sequence_end: 4,
             path_start: 9,
@@ -769,7 +768,7 @@ mod tests {
         let insert = NewBlock {
             id: 0,
             sequence: insert_sequence.clone(),
-            block_sequence: insert_sequence.sequence[0..4].to_string(),
+            block_sequence: insert_sequence.get_sequence(0, 4).to_string(),
             sequence_start: 0,
             sequence_end: 4,
             path_start: 10,
@@ -800,7 +799,7 @@ mod tests {
         let insert = NewBlock {
             id: 0,
             sequence: insert_sequence.clone(),
-            block_sequence: insert_sequence.sequence[0..4].to_string(),
+            block_sequence: insert_sequence.get_sequence(0, 4).to_string(),
             sequence_start: 0,
             sequence_end: 4,
             path_start: 15,
@@ -831,7 +830,7 @@ mod tests {
         let insert = NewBlock {
             id: 0,
             sequence: insert_sequence.clone(),
-            block_sequence: insert_sequence.sequence[0..4].to_string(),
+            block_sequence: insert_sequence.get_sequence(0, 4).to_string(),
             sequence_start: 0,
             sequence_end: 4,
             path_start: 5,
@@ -895,7 +894,7 @@ mod tests {
         let insert = NewBlock {
             id: 0,
             sequence: insert_sequence.clone(),
-            block_sequence: insert_sequence.sequence[0..4].to_string(),
+            block_sequence: insert_sequence.get_sequence(0, 4).to_string(),
             sequence_start: 0,
             sequence_end: 4,
             path_start: 7,

--- a/src/models/block_group.rs
+++ b/src/models/block_group.rs
@@ -202,7 +202,7 @@ impl BlockGroup {
                 }
                 let last_edge = &sorted_sequence_edges[sorted_sequence_edges.len() - 1];
                 let start = last_edge.target_coordinate;
-                let end = sequence.sequence.len() as i32;
+                let end = sequence.length;
                 let block_sequence = sequence.get_sequence(start, end).to_string();
                 let last_block = GroupBlock {
                     id: block_index,
@@ -219,7 +219,7 @@ impl BlockGroup {
                     sequence_hash: hash.clone(),
                     sequence: sequence.sequence.clone(),
                     start: 0,
-                    end: sequence.sequence.len() as i32,
+                    end: sequence.length,
                 });
                 block_index += 1;
             }

--- a/src/models/block_group.rs
+++ b/src/models/block_group.rs
@@ -9,7 +9,7 @@ use crate::models::block_group_edge::BlockGroupEdge;
 use crate::models::edge::{Edge, EdgeData};
 use crate::models::path::{NewBlock, Path};
 use crate::models::path_edge::PathEdge;
-use crate::models::sequence::Sequence;
+use crate::models::sequence::{NewSequence, Sequence};
 
 #[derive(Debug)]
 pub struct BlockGroup {
@@ -454,10 +454,22 @@ mod tests {
     }
 
     fn setup_block_group(conn: &Connection) -> (i32, Path) {
-        let a_seq_hash = Sequence::create(conn, "DNA", "AAAAAAAAAA", true);
-        let t_seq_hash = Sequence::create(conn, "DNA", "TTTTTTTTTT", true);
-        let c_seq_hash = Sequence::create(conn, "DNA", "CCCCCCCCCC", true);
-        let g_seq_hash = Sequence::create(conn, "DNA", "GGGGGGGGGG", true);
+        let a_seq_hash = NewSequence::new()
+            .sequence_type("DNA")
+            .sequence("AAAAAAAAAA")
+            .save(conn);
+        let t_seq_hash = NewSequence::new()
+            .sequence_type("DNA")
+            .sequence("TTTTTTTTTT")
+            .save(conn);
+        let c_seq_hash = NewSequence::new()
+            .sequence_type("DNA")
+            .sequence("CCCCCCCCCC")
+            .save(conn);
+        let g_seq_hash = NewSequence::new()
+            .sequence_type("DNA")
+            .sequence("GGGGGGGGGG")
+            .save(conn);
         let _collection = Collection::create(conn, "test");
         let block_group = BlockGroup::create(conn, "test", None, "hg19");
         let edge0 = Edge::create(
@@ -533,7 +545,10 @@ mod tests {
     fn insert_and_deletion_new_get_all() {
         let mut conn = get_connection();
         let (block_group_id, path) = setup_block_group(&conn);
-        let insert_sequence_hash = Sequence::create(&conn, "DNA", "NNNN", true);
+        let insert_sequence_hash = NewSequence::new()
+            .sequence_type("DNA")
+            .sequence("NNNN")
+            .save(&conn);
         let insert_sequence = Sequence::sequence_from_hash(&conn, &insert_sequence_hash).unwrap();
         let insert = NewBlock {
             id: 0,
@@ -556,7 +571,10 @@ mod tests {
             ])
         );
 
-        let deletion_sequence_hash = Sequence::create(&conn, "DNA", "", true);
+        let deletion_sequence_hash = NewSequence::new()
+            .sequence_type("DNA")
+            .sequence("")
+            .save(&conn);
         let deletion_sequence =
             Sequence::sequence_from_hash(&conn, &deletion_sequence_hash).unwrap();
         let deletion = NewBlock {
@@ -588,7 +606,10 @@ mod tests {
     fn simple_insert_new_get_all() {
         let mut conn = get_connection();
         let (block_group_id, path) = setup_block_group(&conn);
-        let insert_sequence_hash = Sequence::create(&conn, "DNA", "NNNN", true);
+        let insert_sequence_hash = NewSequence::new()
+            .sequence_type("DNA")
+            .sequence("NNNN")
+            .save(&conn);
         let insert_sequence = Sequence::sequence_from_hash(&conn, &insert_sequence_hash).unwrap();
         let insert = NewBlock {
             id: 0,
@@ -616,7 +637,10 @@ mod tests {
     fn insert_on_block_boundary_middle_new() {
         let mut conn = get_connection();
         let (block_group_id, path) = setup_block_group(&conn);
-        let insert_sequence_hash = Sequence::create(&conn, "DNA", "NNNN", true);
+        let insert_sequence_hash = NewSequence::new()
+            .sequence_type("DNA")
+            .sequence("NNNN")
+            .save(&conn);
         let insert_sequence = Sequence::sequence_from_hash(&conn, &insert_sequence_hash).unwrap();
         let insert = NewBlock {
             id: 0,
@@ -644,7 +668,10 @@ mod tests {
     fn insert_within_block_new() {
         let mut conn = get_connection();
         let (block_group_id, path) = setup_block_group(&conn);
-        let insert_sequence_hash = Sequence::create(&conn, "DNA", "NNNN", true);
+        let insert_sequence_hash = NewSequence::new()
+            .sequence_type("DNA")
+            .sequence("NNNN")
+            .save(&conn);
         let insert_sequence = Sequence::sequence_from_hash(&conn, &insert_sequence_hash).unwrap();
         let insert = NewBlock {
             id: 0,
@@ -672,7 +699,10 @@ mod tests {
     fn insert_on_block_boundary_start_new() {
         let mut conn = get_connection();
         let (block_group_id, path) = setup_block_group(&conn);
-        let insert_sequence_hash = Sequence::create(&conn, "DNA", "NNNN", true);
+        let insert_sequence_hash = NewSequence::new()
+            .sequence_type("DNA")
+            .sequence("NNNN")
+            .save(&conn);
         let insert_sequence = Sequence::sequence_from_hash(&conn, &insert_sequence_hash).unwrap();
         let insert = NewBlock {
             id: 0,
@@ -700,7 +730,10 @@ mod tests {
     fn insert_on_block_boundary_end_new() {
         let mut conn = get_connection();
         let (block_group_id, path) = setup_block_group(&conn);
-        let insert_sequence_hash = Sequence::create(&conn, "DNA", "NNNN", true);
+        let insert_sequence_hash = NewSequence::new()
+            .sequence_type("DNA")
+            .sequence("NNNN")
+            .save(&conn);
         let insert_sequence = Sequence::sequence_from_hash(&conn, &insert_sequence_hash).unwrap();
         let insert = NewBlock {
             id: 0,
@@ -728,7 +761,10 @@ mod tests {
     fn insert_across_entire_block_boundary_new() {
         let mut conn = get_connection();
         let (block_group_id, path) = setup_block_group(&conn);
-        let insert_sequence_hash = Sequence::create(&conn, "DNA", "NNNN", true);
+        let insert_sequence_hash = NewSequence::new()
+            .sequence_type("DNA")
+            .sequence("NNNN")
+            .save(&conn);
         let insert_sequence = Sequence::sequence_from_hash(&conn, &insert_sequence_hash).unwrap();
         let insert = NewBlock {
             id: 0,
@@ -756,7 +792,10 @@ mod tests {
     fn insert_across_two_blocks_new() {
         let mut conn = get_connection();
         let (block_group_id, path) = setup_block_group(&conn);
-        let insert_sequence_hash = Sequence::create(&conn, "DNA", "NNNN", true);
+        let insert_sequence_hash = NewSequence::new()
+            .sequence_type("DNA")
+            .sequence("NNNN")
+            .save(&conn);
         let insert_sequence = Sequence::sequence_from_hash(&conn, &insert_sequence_hash).unwrap();
         let insert = NewBlock {
             id: 0,
@@ -784,7 +823,10 @@ mod tests {
     fn insert_spanning_blocks_new() {
         let mut conn = get_connection();
         let (block_group_id, path) = setup_block_group(&conn);
-        let insert_sequence_hash = Sequence::create(&conn, "DNA", "NNNN", true);
+        let insert_sequence_hash = NewSequence::new()
+            .sequence_type("DNA")
+            .sequence("NNNN")
+            .save(&conn);
         let insert_sequence = Sequence::sequence_from_hash(&conn, &insert_sequence_hash).unwrap();
         let insert = NewBlock {
             id: 0,
@@ -812,7 +854,10 @@ mod tests {
     fn simple_deletion_new() {
         let mut conn = get_connection();
         let (block_group_id, path) = setup_block_group(&conn);
-        let deletion_sequence_hash = Sequence::create(&conn, "DNA", "", true);
+        let deletion_sequence_hash = NewSequence::new()
+            .sequence_type("DNA")
+            .sequence("")
+            .save(&conn);
         let deletion_sequence =
             Sequence::sequence_from_hash(&conn, &deletion_sequence_hash).unwrap();
         let deletion = NewBlock {
@@ -842,7 +887,10 @@ mod tests {
     fn doesnt_apply_same_insert_twice_new() {
         let mut conn = get_connection();
         let (block_group_id, path) = setup_block_group(&conn);
-        let insert_sequence_hash = Sequence::create(&conn, "DNA", "NNNN", true);
+        let insert_sequence_hash = NewSequence::new()
+            .sequence_type("DNA")
+            .sequence("NNNN")
+            .save(&conn);
         let insert_sequence = Sequence::sequence_from_hash(&conn, &insert_sequence_hash).unwrap();
         let insert = NewBlock {
             id: 0,

--- a/src/models/block_group.rs
+++ b/src/models/block_group.rs
@@ -453,19 +453,19 @@ mod tests {
     }
 
     fn setup_block_group(conn: &Connection) -> (i32, Path) {
-        let a_seq_hash = NewSequence::new()
+        let a_seq_hash = Sequence::new()
             .sequence_type("DNA")
             .sequence("AAAAAAAAAA")
             .save(conn);
-        let t_seq_hash = NewSequence::new()
+        let t_seq_hash = Sequence::new()
             .sequence_type("DNA")
             .sequence("TTTTTTTTTT")
             .save(conn);
-        let c_seq_hash = NewSequence::new()
+        let c_seq_hash = Sequence::new()
             .sequence_type("DNA")
             .sequence("CCCCCCCCCC")
             .save(conn);
-        let g_seq_hash = NewSequence::new()
+        let g_seq_hash = Sequence::new()
             .sequence_type("DNA")
             .sequence("GGGGGGGGGG")
             .save(conn);
@@ -544,7 +544,7 @@ mod tests {
     fn insert_and_deletion_new_get_all() {
         let mut conn = get_connection();
         let (block_group_id, path) = setup_block_group(&conn);
-        let insert_sequence_hash = NewSequence::new()
+        let insert_sequence_hash = Sequence::new()
             .sequence_type("DNA")
             .sequence("NNNN")
             .save(&conn);
@@ -570,7 +570,7 @@ mod tests {
             ])
         );
 
-        let deletion_sequence_hash = NewSequence::new()
+        let deletion_sequence_hash = Sequence::new()
             .sequence_type("DNA")
             .sequence("")
             .save(&conn);
@@ -605,7 +605,7 @@ mod tests {
     fn simple_insert_new_get_all() {
         let mut conn = get_connection();
         let (block_group_id, path) = setup_block_group(&conn);
-        let insert_sequence_hash = NewSequence::new()
+        let insert_sequence_hash = Sequence::new()
             .sequence_type("DNA")
             .sequence("NNNN")
             .save(&conn);
@@ -636,7 +636,7 @@ mod tests {
     fn insert_on_block_boundary_middle_new() {
         let mut conn = get_connection();
         let (block_group_id, path) = setup_block_group(&conn);
-        let insert_sequence_hash = NewSequence::new()
+        let insert_sequence_hash = Sequence::new()
             .sequence_type("DNA")
             .sequence("NNNN")
             .save(&conn);
@@ -667,7 +667,7 @@ mod tests {
     fn insert_within_block_new() {
         let mut conn = get_connection();
         let (block_group_id, path) = setup_block_group(&conn);
-        let insert_sequence_hash = NewSequence::new()
+        let insert_sequence_hash = Sequence::new()
             .sequence_type("DNA")
             .sequence("NNNN")
             .save(&conn);
@@ -698,7 +698,7 @@ mod tests {
     fn insert_on_block_boundary_start_new() {
         let mut conn = get_connection();
         let (block_group_id, path) = setup_block_group(&conn);
-        let insert_sequence_hash = NewSequence::new()
+        let insert_sequence_hash = Sequence::new()
             .sequence_type("DNA")
             .sequence("NNNN")
             .save(&conn);
@@ -729,7 +729,7 @@ mod tests {
     fn insert_on_block_boundary_end_new() {
         let mut conn = get_connection();
         let (block_group_id, path) = setup_block_group(&conn);
-        let insert_sequence_hash = NewSequence::new()
+        let insert_sequence_hash = Sequence::new()
             .sequence_type("DNA")
             .sequence("NNNN")
             .save(&conn);
@@ -760,7 +760,7 @@ mod tests {
     fn insert_across_entire_block_boundary_new() {
         let mut conn = get_connection();
         let (block_group_id, path) = setup_block_group(&conn);
-        let insert_sequence_hash = NewSequence::new()
+        let insert_sequence_hash = Sequence::new()
             .sequence_type("DNA")
             .sequence("NNNN")
             .save(&conn);
@@ -791,7 +791,7 @@ mod tests {
     fn insert_across_two_blocks_new() {
         let mut conn = get_connection();
         let (block_group_id, path) = setup_block_group(&conn);
-        let insert_sequence_hash = NewSequence::new()
+        let insert_sequence_hash = Sequence::new()
             .sequence_type("DNA")
             .sequence("NNNN")
             .save(&conn);
@@ -822,7 +822,7 @@ mod tests {
     fn insert_spanning_blocks_new() {
         let mut conn = get_connection();
         let (block_group_id, path) = setup_block_group(&conn);
-        let insert_sequence_hash = NewSequence::new()
+        let insert_sequence_hash = Sequence::new()
             .sequence_type("DNA")
             .sequence("NNNN")
             .save(&conn);
@@ -853,7 +853,7 @@ mod tests {
     fn simple_deletion_new() {
         let mut conn = get_connection();
         let (block_group_id, path) = setup_block_group(&conn);
-        let deletion_sequence_hash = NewSequence::new()
+        let deletion_sequence_hash = Sequence::new()
             .sequence_type("DNA")
             .sequence("")
             .save(&conn);
@@ -886,7 +886,7 @@ mod tests {
     fn doesnt_apply_same_insert_twice_new() {
         let mut conn = get_connection();
         let (block_group_id, path) = setup_block_group(&conn);
-        let insert_sequence_hash = NewSequence::new()
+        let insert_sequence_hash = Sequence::new()
             .sequence_type("DNA")
             .sequence("NNNN")
             .save(&conn);

--- a/src/models/edge.rs
+++ b/src/models/edge.rs
@@ -233,7 +233,7 @@ mod tests {
     use std::collections::HashMap;
 
     use crate::migrations::run_migrations;
-    use crate::models::{sequence::Sequence, Collection};
+    use crate::models::{sequence::NewSequence, Collection};
 
     fn get_connection() -> Connection {
         let mut conn = Connection::open_in_memory()
@@ -247,7 +247,10 @@ mod tests {
     fn test_bulk_create() {
         let conn = &mut get_connection();
         Collection::create(conn, "test collection");
-        let sequence1_hash = Sequence::create(conn, "DNA", "ATCGATCG", true);
+        let sequence1_hash = NewSequence::new()
+            .sequence_type("DNA")
+            .sequence("ATCGATCG")
+            .save(conn);
         let edge1 = EdgeData {
             source_hash: Edge::PATH_START_HASH.to_string(),
             source_coordinate: -1,
@@ -258,7 +261,10 @@ mod tests {
             chromosome_index: 0,
             phased: 0,
         };
-        let sequence2_hash = Sequence::create(conn, "DNA", "AAAAAAAA", true);
+        let sequence2_hash = NewSequence::new()
+            .sequence_type("DNA")
+            .sequence("AAAAAAAA")
+            .save(conn);
         let edge2 = EdgeData {
             source_hash: sequence1_hash.clone(),
             source_coordinate: 2,
@@ -308,7 +314,10 @@ mod tests {
     fn test_bulk_create_with_existing_edge() {
         let conn = &mut get_connection();
         Collection::create(conn, "test collection");
-        let sequence1_hash = Sequence::create(conn, "DNA", "ATCGATCG", true);
+        let sequence1_hash = NewSequence::new()
+            .sequence_type("DNA")
+            .sequence("ATCGATCG")
+            .save(conn);
         // NOTE: Create one edge ahead of time to confirm an existing row ID gets returned in the bulk create
         let existing_edge = Edge::create(
             conn,
@@ -336,7 +345,10 @@ mod tests {
             chromosome_index: 0,
             phased: 0,
         };
-        let sequence2_hash = Sequence::create(conn, "DNA", "AAAAAAAA", true);
+        let sequence2_hash = NewSequence::new()
+            .sequence_type("DNA")
+            .sequence("AAAAAAAA")
+            .save(conn);
         let edge2 = EdgeData {
             source_hash: sequence1_hash.clone(),
             source_coordinate: 2,

--- a/src/models/edge.rs
+++ b/src/models/edge.rs
@@ -233,7 +233,7 @@ mod tests {
     use std::collections::HashMap;
 
     use crate::migrations::run_migrations;
-    use crate::models::{sequence::NewSequence, Collection};
+    use crate::models::{sequence::Sequence, Collection};
 
     fn get_connection() -> Connection {
         let mut conn = Connection::open_in_memory()
@@ -247,7 +247,7 @@ mod tests {
     fn test_bulk_create() {
         let conn = &mut get_connection();
         Collection::create(conn, "test collection");
-        let sequence1_hash = NewSequence::new()
+        let sequence1_hash = Sequence::new()
             .sequence_type("DNA")
             .sequence("ATCGATCG")
             .save(conn);
@@ -261,7 +261,7 @@ mod tests {
             chromosome_index: 0,
             phased: 0,
         };
-        let sequence2_hash = NewSequence::new()
+        let sequence2_hash = Sequence::new()
             .sequence_type("DNA")
             .sequence("AAAAAAAA")
             .save(conn);
@@ -314,7 +314,7 @@ mod tests {
     fn test_bulk_create_with_existing_edge() {
         let conn = &mut get_connection();
         Collection::create(conn, "test collection");
-        let sequence1_hash = NewSequence::new()
+        let sequence1_hash = Sequence::new()
             .sequence_type("DNA")
             .sequence("ATCGATCG")
             .save(conn);
@@ -345,7 +345,7 @@ mod tests {
             chromosome_index: 0,
             phased: 0,
         };
-        let sequence2_hash = NewSequence::new()
+        let sequence2_hash = Sequence::new()
             .sequence_type("DNA")
             .sequence("AAAAAAAA")
             .save(conn);

--- a/src/models/path.rs
+++ b/src/models/path.rs
@@ -155,9 +155,9 @@ impl Path {
         }
 
         let block_sequence = if strand == "-" {
-            revcomp(&sequence.sequence[start as usize..end as usize])
+            revcomp(&sequence.get_sequence(start, end))
         } else {
-            sequence.sequence[start as usize..end as usize].to_string()
+            sequence.get_sequence(start, end)
         };
 
         NewBlock {

--- a/src/models/path.rs
+++ b/src/models/path.rs
@@ -234,7 +234,7 @@ mod tests {
         let conn = &mut get_connection();
         Collection::create(conn, "test collection");
         let block_group = BlockGroup::create(conn, "test collection", None, "test block group");
-        let sequence1_hash = NewSequence::new()
+        let sequence1_hash = Sequence::new()
             .sequence_type("DNA")
             .sequence("ATCGATCG")
             .save(conn);
@@ -249,7 +249,7 @@ mod tests {
             0,
             0,
         );
-        let sequence2_hash = NewSequence::new()
+        let sequence2_hash = Sequence::new()
             .sequence_type("DNA")
             .sequence("AAAAAAAA")
             .save(conn);
@@ -264,7 +264,7 @@ mod tests {
             0,
             0,
         );
-        let sequence3_hash = NewSequence::new()
+        let sequence3_hash = Sequence::new()
             .sequence_type("DNA")
             .sequence("CCCCCCCC")
             .save(conn);
@@ -279,7 +279,7 @@ mod tests {
             0,
             0,
         );
-        let sequence4_hash = NewSequence::new()
+        let sequence4_hash = Sequence::new()
             .sequence_type("DNA")
             .sequence("GGGGGGGG")
             .save(conn);
@@ -320,7 +320,7 @@ mod tests {
         let conn = &mut get_connection();
         Collection::create(conn, "test collection");
         let block_group = BlockGroup::create(conn, "test collection", None, "test block group");
-        let sequence1_hash = NewSequence::new()
+        let sequence1_hash = Sequence::new()
             .sequence_type("DNA")
             .sequence("ATCGATCG")
             .save(conn);
@@ -335,7 +335,7 @@ mod tests {
             0,
             0,
         );
-        let sequence2_hash = NewSequence::new()
+        let sequence2_hash = Sequence::new()
             .sequence_type("DNA")
             .sequence("AAAAAAAA")
             .save(conn);
@@ -350,7 +350,7 @@ mod tests {
             0,
             0,
         );
-        let sequence3_hash = NewSequence::new()
+        let sequence3_hash = Sequence::new()
             .sequence_type("DNA")
             .sequence("CCCCCCCC")
             .save(conn);
@@ -365,7 +365,7 @@ mod tests {
             0,
             0,
         );
-        let sequence4_hash = NewSequence::new()
+        let sequence4_hash = Sequence::new()
             .sequence_type("DNA")
             .sequence("GGGGGGGG")
             .save(conn);
@@ -413,7 +413,7 @@ mod tests {
         let conn = &mut get_connection();
         Collection::create(conn, "test collection");
         let block_group = BlockGroup::create(conn, "test collection", None, "test block group");
-        let sequence1_hash = NewSequence::new()
+        let sequence1_hash = Sequence::new()
             .sequence_type("DNA")
             .sequence("ATCGATCG")
             .save(conn);
@@ -428,7 +428,7 @@ mod tests {
             0,
             0,
         );
-        let sequence2_hash = NewSequence::new()
+        let sequence2_hash = Sequence::new()
             .sequence_type("DNA")
             .sequence("AAAAAAAA")
             .save(conn);
@@ -443,7 +443,7 @@ mod tests {
             0,
             0,
         );
-        let sequence3_hash = NewSequence::new()
+        let sequence3_hash = Sequence::new()
             .sequence_type("DNA")
             .sequence("CCCCCCCC")
             .save(conn);
@@ -458,7 +458,7 @@ mod tests {
             0,
             0,
         );
-        let sequence4_hash = NewSequence::new()
+        let sequence4_hash = Sequence::new()
             .sequence_type("DNA")
             .sequence("GGGGGGGG")
             .save(conn);

--- a/src/models/path.rs
+++ b/src/models/path.rs
@@ -219,7 +219,7 @@ mod tests {
     use super::*;
 
     use crate::migrations::run_migrations;
-    use crate::models::{block_group::BlockGroup, sequence::Sequence, Collection};
+    use crate::models::{block_group::BlockGroup, sequence::NewSequence, Collection};
 
     fn get_connection() -> Connection {
         let mut conn = Connection::open_in_memory()
@@ -234,7 +234,10 @@ mod tests {
         let conn = &mut get_connection();
         Collection::create(conn, "test collection");
         let block_group = BlockGroup::create(conn, "test collection", None, "test block group");
-        let sequence1_hash = Sequence::create(conn, "DNA", "ATCGATCG", true);
+        let sequence1_hash = NewSequence::new()
+            .sequence_type("DNA")
+            .sequence("ATCGATCG")
+            .save(conn);
         let edge1 = Edge::create(
             conn,
             Edge::PATH_START_HASH.to_string(),
@@ -246,7 +249,10 @@ mod tests {
             0,
             0,
         );
-        let sequence2_hash = Sequence::create(conn, "DNA", "AAAAAAAA", true);
+        let sequence2_hash = NewSequence::new()
+            .sequence_type("DNA")
+            .sequence("AAAAAAAA")
+            .save(conn);
         let edge2 = Edge::create(
             conn,
             sequence1_hash.clone(),
@@ -258,7 +264,10 @@ mod tests {
             0,
             0,
         );
-        let sequence3_hash = Sequence::create(conn, "DNA", "CCCCCCCC", true);
+        let sequence3_hash = NewSequence::new()
+            .sequence_type("DNA")
+            .sequence("CCCCCCCC")
+            .save(conn);
         let edge3 = Edge::create(
             conn,
             sequence2_hash.clone(),
@@ -270,7 +279,10 @@ mod tests {
             0,
             0,
         );
-        let sequence4_hash = Sequence::create(conn, "DNA", "GGGGGGGG", true);
+        let sequence4_hash = NewSequence::new()
+            .sequence_type("DNA")
+            .sequence("GGGGGGGG")
+            .save(conn);
         let edge4 = Edge::create(
             conn,
             sequence3_hash.clone(),
@@ -308,7 +320,10 @@ mod tests {
         let conn = &mut get_connection();
         Collection::create(conn, "test collection");
         let block_group = BlockGroup::create(conn, "test collection", None, "test block group");
-        let sequence1_hash = Sequence::create(conn, "DNA", "ATCGATCG", true);
+        let sequence1_hash = NewSequence::new()
+            .sequence_type("DNA")
+            .sequence("ATCGATCG")
+            .save(conn);
         let edge5 = Edge::create(
             conn,
             sequence1_hash.clone(),
@@ -320,7 +335,10 @@ mod tests {
             0,
             0,
         );
-        let sequence2_hash = Sequence::create(conn, "DNA", "AAAAAAAA", true);
+        let sequence2_hash = NewSequence::new()
+            .sequence_type("DNA")
+            .sequence("AAAAAAAA")
+            .save(conn);
         let edge4 = Edge::create(
             conn,
             sequence2_hash.clone(),
@@ -332,7 +350,10 @@ mod tests {
             0,
             0,
         );
-        let sequence3_hash = Sequence::create(conn, "DNA", "CCCCCCCC", true);
+        let sequence3_hash = NewSequence::new()
+            .sequence_type("DNA")
+            .sequence("CCCCCCCC")
+            .save(conn);
         let edge3 = Edge::create(
             conn,
             sequence3_hash.clone(),
@@ -344,7 +365,10 @@ mod tests {
             0,
             0,
         );
-        let sequence4_hash = Sequence::create(conn, "DNA", "GGGGGGGG", true);
+        let sequence4_hash = NewSequence::new()
+            .sequence_type("DNA")
+            .sequence("GGGGGGGG")
+            .save(conn);
         let edge2 = Edge::create(
             conn,
             sequence4_hash.clone(),
@@ -389,7 +413,10 @@ mod tests {
         let conn = &mut get_connection();
         Collection::create(conn, "test collection");
         let block_group = BlockGroup::create(conn, "test collection", None, "test block group");
-        let sequence1_hash = Sequence::create(conn, "DNA", "ATCGATCG", true);
+        let sequence1_hash = NewSequence::new()
+            .sequence_type("DNA")
+            .sequence("ATCGATCG")
+            .save(conn);
         let edge1 = Edge::create(
             conn,
             Edge::PATH_START_HASH.to_string(),
@@ -401,7 +428,10 @@ mod tests {
             0,
             0,
         );
-        let sequence2_hash = Sequence::create(conn, "DNA", "AAAAAAAA", true);
+        let sequence2_hash = NewSequence::new()
+            .sequence_type("DNA")
+            .sequence("AAAAAAAA")
+            .save(conn);
         let edge2 = Edge::create(
             conn,
             sequence1_hash.clone(),
@@ -413,7 +443,10 @@ mod tests {
             0,
             0,
         );
-        let sequence3_hash = Sequence::create(conn, "DNA", "CCCCCCCC", true);
+        let sequence3_hash = NewSequence::new()
+            .sequence_type("DNA")
+            .sequence("CCCCCCCC")
+            .save(conn);
         let edge3 = Edge::create(
             conn,
             sequence2_hash.clone(),
@@ -425,7 +458,10 @@ mod tests {
             0,
             0,
         );
-        let sequence4_hash = Sequence::create(conn, "DNA", "GGGGGGGG", true);
+        let sequence4_hash = NewSequence::new()
+            .sequence_type("DNA")
+            .sequence("GGGGGGGG")
+            .save(conn);
         let edge4 = Edge::create(
             conn,
             sequence3_hash.clone(),

--- a/src/models/sequence.rs
+++ b/src/models/sequence.rs
@@ -8,14 +8,94 @@ pub struct Sequence {
     pub hash: String,
     pub sequence_type: String,
     pub sequence: String,
+    // these 2 fields are only relevant when the sequence is stored externally
+    pub name: String,
+    pub file_path: String,
     pub length: i32,
+    // indicates whether the sequence is stored externally, a quick flag instead of having to
+    // check sequence or file_path and do the logic in function calls.
+    pub external_sequence: bool,
 }
 
-impl Sequence {
-    pub fn create(conn: &Connection, sequence_type: &str, sequence: &str, store: bool) -> String {
+#[derive(Default)]
+pub struct NewSequence<'a> {
+    sequence_type: Option<&'a str>,
+    sequence: Option<&'a str>,
+    name: Option<&'a str>,
+    file_path: Option<&'a str>,
+    length: Option<i32>,
+    shallow: bool,
+}
+
+impl<'a> NewSequence<'a> {
+    pub fn new() -> NewSequence<'static> {
+        NewSequence {
+            shallow: false,
+            ..NewSequence::default()
+        }
+    }
+
+    pub fn shallow(mut self, setting: bool) -> Self {
+        self.shallow = setting;
+        self
+    }
+
+    pub fn sequence_type(mut self, seq_type: &'a str) -> Self {
+        self.sequence_type = Some(seq_type);
+        self
+    }
+
+    pub fn sequence(mut self, sequence: &'a str) -> Self {
+        self.sequence = Some(sequence);
+        self
+    }
+
+    pub fn name(mut self, name: &'a str) -> Self {
+        self.name = Some(name);
+        self
+    }
+
+    pub fn file_path(mut self, path: &'a str) -> Self {
+        self.file_path = Some(path);
+        self.shallow = true;
+        self
+    }
+
+    pub fn length(mut self, length: i32) -> Self {
+        self.length = Some(length);
+        self
+    }
+
+    pub fn save(mut self, conn: &Connection) -> String {
+        let mut length = 0;
+        if self.sequence.is_none() && self.file_path.is_none() {
+            panic!("Sequence or file_path must be set.");
+        }
+        if self.file_path.is_some() && self.name.is_none() {
+            panic!("A filepath must have an accompanying sequence name");
+        }
+        if self.length.is_none() {
+            if let Some(v) = self.sequence {
+                length = v.len() as i32;
+            } else {
+                panic!("Sequence length must be specified.");
+            }
+        }
         let mut hasher = Sha256::new();
-        hasher.update(sequence_type);
-        hasher.update(sequence);
+        hasher.update(self.sequence_type.expect("Sequence type must be defined."));
+        hasher.update(";");
+        if let Some(v) = self.sequence {
+            hasher.update(v);
+            hasher.update(";");
+        }
+        if let Some(v) = self.name {
+            hasher.update(v);
+            hasher.update(";");
+        }
+        if let Some(v) = self.file_path {
+            hasher.update(v);
+            hasher.update(";");
+        }
         let hash = format!("{:x}", hasher.finalize());
         let mut obj_hash: String = match conn.query_row(
             "SELECT hash from sequence where hash = ?1;",
@@ -29,14 +109,23 @@ impl Sequence {
             }
         };
         if obj_hash.is_empty() {
-            let mut stmt = conn.prepare("INSERT INTO sequence (hash, sequence_type, sequence, length) VALUES (?1, ?2, ?3, ?4) RETURNING (hash);").unwrap();
+            let mut stmt = conn.prepare("INSERT INTO sequence (hash, sequence_type, sequence, name, file_path, length) VALUES (?1, ?2, ?3, ?4, ?5, ?6) RETURNING (hash);").unwrap();
             let mut rows = stmt
                 .query_map(
                     (
                         Value::from(hash.to_string()),
-                        Value::from(sequence_type.to_string()),
-                        Value::from((if store { sequence } else { "" }).to_string()),
-                        Value::from(sequence.len() as i32),
+                        Value::from(self.sequence_type.unwrap().to_string()),
+                        Value::from(
+                            (if self.shallow {
+                                ""
+                            } else {
+                                self.sequence.unwrap()
+                            })
+                            .to_string(),
+                        ),
+                        Value::from(self.name.unwrap_or("").to_string()),
+                        Value::from(self.file_path.unwrap_or("").to_string()),
+                        Value::from(self.length.unwrap_or(length)),
                     ),
                     |row| row.get(0),
                 )
@@ -45,16 +134,26 @@ impl Sequence {
         }
         obj_hash
     }
+}
 
+impl Sequence {
     pub fn sequences(conn: &Connection, query: &str, placeholders: Vec<Value>) -> Vec<Sequence> {
         let mut stmt = conn.prepare_cached(query).unwrap();
         let rows = stmt
             .query_map(params_from_iter(placeholders), |row| {
+                let file_path: String = row.get(4).unwrap();
+                let mut external_sequence = false;
+                if !file_path.is_empty() {
+                    external_sequence = true;
+                }
                 Ok(Sequence {
                     hash: row.get(0).unwrap(),
                     sequence_type: row.get(1).unwrap(),
                     sequence: row.get(2).unwrap(),
-                    length: row.get(3).unwrap(),
+                    name: row.get(3).unwrap(),
+                    file_path,
+                    length: row.get(5).unwrap(),
+                    external_sequence,
                 })
             })
             .unwrap();
@@ -85,5 +184,63 @@ impl Sequence {
     pub fn sequence_from_hash(conn: &Connection, hash: &str) -> Option<Sequence> {
         let sequences_by_hash = Sequence::sequences_by_hash(conn, vec![hash.to_string()]);
         sequences_by_hash.get(hash).cloned()
+    }
+}
+
+mod tests {
+    use rusqlite::Connection;
+    use std::ops::Deref;
+    // Note this useful idiom: importing names from outer (for mod tests) scope.
+    use super::*;
+
+    use crate::migrations::run_migrations;
+
+    fn get_connection() -> Connection {
+        let mut conn = Connection::open_in_memory()
+            .unwrap_or_else(|_| panic!("Error opening in memory test db"));
+        rusqlite::vtab::array::load_module(&conn).unwrap();
+        run_migrations(&mut conn);
+        conn
+    }
+
+    #[test]
+    fn test_create_sequence_in_db() {
+        let conn = &mut get_connection();
+        let seq_hash = NewSequence::new()
+            .sequence_type("DNA")
+            .sequence("AACCTT")
+            .save(conn);
+        let sequences = Sequence::sequences(
+            conn,
+            "select * from sequence where hash = ?1",
+            vec![Value::from(seq_hash)],
+        );
+        let sequence = sequences.first().unwrap();
+        assert_eq!(&sequence.sequence, "AACCTT");
+        assert_eq!(sequence.sequence_type, "DNA");
+        assert!(!sequence.external_sequence);
+    }
+
+    #[test]
+    fn test_create_sequence_on_disk() {
+        let conn = &mut get_connection();
+        let seq_hash = NewSequence::new()
+            .sequence_type("DNA")
+            .name("chr1")
+            .file_path("/some/path.fa")
+            .length(10)
+            .save(conn);
+        let sequences = Sequence::sequences(
+            conn,
+            "select * from sequence where hash = ?1",
+            vec![Value::from(seq_hash)],
+        );
+        let sequence = sequences.first().unwrap();
+        assert_eq!(sequence.sequence_type, "DNA");
+        assert_eq!(&sequence.sequence, "");
+        assert_eq!(sequence.name, "chr1");
+        assert_eq!(sequence.file_path, "/some/path.fa");
+        assert_eq!(sequence.length, 10);
+        assert!(sequence.external_sequence);
     }
 }

--- a/src/models/sequence.rs
+++ b/src/models/sequence.rs
@@ -31,6 +31,13 @@ pub struct NewSequence<'a> {
 }
 
 impl<'a> NewSequence<'a> {
+    pub fn new() -> NewSequence<'static> {
+        NewSequence {
+            shallow: false,
+            ..NewSequence::default()
+        }
+    }
+
     pub fn shallow(mut self, setting: bool) -> Self {
         self.shallow = setting;
         self
@@ -155,11 +162,9 @@ impl<'a> NewSequence<'a> {
 impl Sequence {
     #[allow(clippy::new_ret_no_self)]
     pub fn new() -> NewSequence<'static> {
-        NewSequence {
-            shallow: false,
-            ..NewSequence::default()
-        }
+        NewSequence::new()
     }
+
     pub fn get_sequence(
         &self,
         start: impl Into<Option<i32>>,

--- a/src/models/sequence.rs
+++ b/src/models/sequence.rs
@@ -10,7 +10,7 @@ use std::{fs, path::PathBuf, str};
 pub struct Sequence {
     pub hash: String,
     pub sequence_type: String,
-    pub sequence: String,
+    sequence: String,
     // these 2 fields are only relevant when the sequence is stored externally
     pub name: String,
     pub file_path: String,


### PR DESCRIPTION
Support storing sequences on disk instead of in db.

The builder pattern is used here, as it allows other defaults to be set automatically which was not possible in the default pattern.

Given that the sequence itself needs some inference to know how to fetch it, sequence was made private as well.