### PR TITLE
Clone edge ids with block group clone

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -137,7 +137,7 @@ fn import_fasta(fasta: &String, name: &str, shallow: bool, conn: &mut Connection
 
 fn update_with_vcf(
     vcf_path: &String,
-    collection_name: &String,
+    collection_name: &str,
     fixed_genotype: String,
     fixed_sample: String,
     conn: &mut Connection,

--- a/src/models.rs
+++ b/src/models.rs
@@ -56,16 +56,20 @@ pub struct Sample {
 }
 
 impl Sample {
-    pub fn create(conn: &Connection, name: &String) -> Sample {
+    pub fn create(conn: &Connection, name: &str) -> Sample {
         let mut stmt = conn
             .prepare("INSERT INTO sample (name) VALUES (?1)")
             .unwrap();
         match stmt.execute((name,)) {
-            Ok(_) => Sample { name: name.clone() },
+            Ok(_) => Sample {
+                name: name.to_string(),
+            },
             Err(rusqlite::Error::SqliteFailure(err, details)) => {
                 if err.code == rusqlite::ErrorCode::ConstraintViolation {
                     println!("{err:?} {details:?}");
-                    Sample { name: name.clone() }
+                    Sample {
+                        name: name.to_string(),
+                    }
                 } else {
                     panic!("something bad happened querying the database")
                 }

--- a/src/models/block_group.rs
+++ b/src/models/block_group.rs
@@ -84,6 +84,12 @@ impl BlockGroup {
             vec![Value::from(source_block_group_id)],
         );
 
+        let edge_ids = BlockGroupEdge::edges_for_block_group(conn, source_block_group_id)
+            .iter()
+            .map(|edge| edge.id)
+            .collect();
+        BlockGroupEdge::bulk_create(conn, target_block_group_id, edge_ids);
+
         for path in existing_paths {
             let edge_ids = PathEdge::edges_for(conn, path.id)
                 .into_iter()

--- a/src/models/edge.rs
+++ b/src/models/edge.rs
@@ -3,7 +3,7 @@ use rusqlite::{params_from_iter, Connection};
 use std::collections::HashSet;
 use std::hash::RandomState;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Edge {
     pub id: i32,
     pub source_hash: String,


### PR DESCRIPTION
Previous clone update omitted non-path edge ids.