### PR TITLE
Custom changeset management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,6 +532,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "clap",
+ "fallible-streaming-iterator",
  "gfa-reader",
  "include_dir",
  "intervaltree",
@@ -540,6 +541,8 @@ dependencies = [
  "petgraph",
  "rusqlite",
  "rusqlite_migration",
+ "serde",
+ "serde_json",
  "sha2",
  "tempdir",
  "tempfile",
@@ -697,6 +700,12 @@ checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
@@ -1355,6 +1364,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
 name = "serde"
 version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1372,6 +1387,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ noodles = { version = "0.78.0", features = ["core", "vcf", "fasta", "async"] }
 petgraph = "0.6.5"
 chrono = "0.4.38"
 tempdir = "0.3.7"
+fallible-streaming-iterator = "0.1.9"
+serde = {  version = "1.0.210", features = ["derive"] }
+serde_json = "1.0.128"

--- a/src/imports/fasta.rs
+++ b/src/imports/fasta.rs
@@ -116,7 +116,6 @@ mod tests {
         let conn = get_connection(None);
         let db_uuid = metadata::get_db_uuid(&conn);
         let op_conn = &get_operation_connection(None);
-        let db_uuid = metadata::get_db_uuid(&conn);
         setup_db(op_conn, &db_uuid);
 
         import_fasta(

--- a/src/imports/fasta.rs
+++ b/src/imports/fasta.rs
@@ -92,7 +92,7 @@ pub fn import_fasta(
         println!("Created it");
         let mut output = Vec::new();
         session.changeset_strm(&mut output).unwrap();
-        operation_management::write_changeset(&operation, &output);
+        operation_management::write_changeset(conn, &operation, &output);
     } else {
         println!("Collection {:1} already exists", name);
     }
@@ -102,6 +102,7 @@ pub fn import_fasta(
 mod tests {
     // Note this useful idiom: importing names from outer (for mod tests) scope.
     use super::*;
+    use crate::models::metadata;
     use crate::models::operations::setup_db;
     use crate::test_helpers::{get_connection, get_operation_connection, setup_gen_dir};
     use std::collections::HashSet;
@@ -113,6 +114,7 @@ mod tests {
         let mut fasta_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         fasta_path.push("fixtures/simple.fa");
         let conn = get_connection(None);
+        let db_uuid = metadata::get_db_uuid(&conn);
         let op_conn = &get_operation_connection(None);
         let db_uuid = metadata::get_db_uuid(&conn);
         setup_db(op_conn, &db_uuid);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ pub fn parse_genotype(gt: &str) -> Vec<Option<Genotype>> {
         true => Phasing::Unphased,
         false => Phasing::Phased,
     };
-    for entry in gt.split_inclusive(|c| c == '|' || c == '/') {
+    for entry in gt.split_inclusive(['|', '/']) {
         let allele;
         let mut phasing = Phasing::Unphased;
         if entry.ends_with(['/', '|']) {

--- a/src/models/block_group.rs
+++ b/src/models/block_group.rs
@@ -1,7 +1,9 @@
+use std::collections::{HashMap, HashSet};
+
 use intervaltree::IntervalTree;
 use petgraph::Direction;
 use rusqlite::{params_from_iter, types::Value as SQLValue, Connection};
-use std::collections::{HashMap, HashSet};
+use serde::{Deserialize, Serialize};
 
 use crate::graph::all_simple_paths;
 use crate::models::block_group_edge::BlockGroupEdge;
@@ -11,7 +13,7 @@ use crate::models::path_edge::PathEdge;
 use crate::models::sequence::Sequence;
 use crate::models::strand::Strand;
 
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct BlockGroup {
     pub id: i32,
     pub collection_name: String,
@@ -104,17 +106,29 @@ impl BlockGroup {
             Err(rusqlite::Error::SqliteFailure(err, details)) => {
                 if err.code == rusqlite::ErrorCode::ConstraintViolation {
                     println!("{err:?} {details:?}");
-                    BlockGroup {
-                        id: conn
+                    let bg_id = match(sample_name) {
+                        Some(v) => {conn
                             .query_row(
-                                "select id from block_group where collection_name = ?1 and sample_name is null and name = ?2",
+                                "select id from block_group where collection_name = ?1 and sample_name = ?2 and name = ?3",
+                                (collection_name, sample_name, name),
+                                |row| row.get(0),
+                            )
+                            .unwrap()}
+                        None => {
+                            conn
+                            .query_row(
+                                "select id from block_group where collection_name = ?1 and sample_name is null and name = ?3",
                                 (collection_name, name),
                                 |row| row.get(0),
                             )
-                            .unwrap(),
+                            .unwrap()
+                        }
+                    };
+                    BlockGroup {
+                        id: bg_id,
                         collection_name: collection_name.to_string(),
                         sample_name: sample_name.map(|s| s.to_string()),
-                        name: name.to_string()
+                        name: name.to_string(),
                     }
                 } else {
                     panic!("something bad happened querying the database")
@@ -416,95 +430,7 @@ impl BlockGroup {
 mod tests {
     use super::*;
     use crate::models::{collection::Collection, sample::Sample};
-    use crate::test_helpers::get_connection;
-
-    fn setup_block_group(conn: &Connection) -> (i32, Path) {
-        let a_seq = Sequence::new()
-            .sequence_type("DNA")
-            .sequence("AAAAAAAAAA")
-            .save(conn);
-        let t_seq = Sequence::new()
-            .sequence_type("DNA")
-            .sequence("TTTTTTTTTT")
-            .save(conn);
-        let c_seq = Sequence::new()
-            .sequence_type("DNA")
-            .sequence("CCCCCCCCCC")
-            .save(conn);
-        let g_seq = Sequence::new()
-            .sequence_type("DNA")
-            .sequence("GGGGGGGGGG")
-            .save(conn);
-        let _collection = Collection::create(conn, "test");
-        let block_group = BlockGroup::create(conn, "test", None, "hg19");
-        let edge0 = Edge::create(
-            conn,
-            Sequence::PATH_START_HASH.to_string(),
-            0,
-            Strand::Forward,
-            a_seq.hash.clone(),
-            0,
-            Strand::Forward,
-            0,
-            0,
-        );
-        let edge1 = Edge::create(
-            conn,
-            a_seq.hash,
-            10,
-            Strand::Forward,
-            t_seq.hash.clone(),
-            0,
-            Strand::Forward,
-            0,
-            0,
-        );
-        let edge2 = Edge::create(
-            conn,
-            t_seq.hash,
-            10,
-            Strand::Forward,
-            c_seq.hash.clone(),
-            0,
-            Strand::Forward,
-            0,
-            0,
-        );
-        let edge3 = Edge::create(
-            conn,
-            c_seq.hash,
-            10,
-            Strand::Forward,
-            g_seq.hash.clone(),
-            0,
-            Strand::Forward,
-            0,
-            0,
-        );
-        let edge4 = Edge::create(
-            conn,
-            g_seq.hash,
-            10,
-            Strand::Forward,
-            Sequence::PATH_END_HASH.to_string(),
-            0,
-            Strand::Forward,
-            0,
-            0,
-        );
-        BlockGroupEdge::bulk_create(
-            conn,
-            block_group.id,
-            &[edge0.id, edge1.id, edge2.id, edge3.id, edge4.id],
-        );
-        let path = Path::create(
-            conn,
-            "chr1",
-            block_group.id,
-            &[edge0.id, edge1.id, edge2.id, edge3.id, edge4.id],
-        );
-        (block_group.id, path)
-    }
+    use crate::test_helpers::{get_connection, setup_block_group};
 
     #[test]
     fn test_blockgroup_create() {

--- a/src/models/block_group.rs
+++ b/src/models/block_group.rs
@@ -106,11 +106,11 @@ impl BlockGroup {
             Err(rusqlite::Error::SqliteFailure(err, details)) => {
                 if err.code == rusqlite::ErrorCode::ConstraintViolation {
                     println!("{err:?} {details:?}");
-                    let bg_id = match(sample_name) {
+                    let bg_id = match sample_name {
                         Some(v) => {conn
                             .query_row(
                                 "select id from block_group where collection_name = ?1 and sample_name = ?2 and name = ?3",
-                                (collection_name, sample_name, name),
+                                (collection_name, v, name),
                                 |row| row.get(0),
                             )
                             .unwrap()}

--- a/src/models/block_group_edge.rs
+++ b/src/models/block_group_edge.rs
@@ -1,4 +1,3 @@
-use crate::models::block_group::BlockGroup;
 use crate::models::edge::Edge;
 use rusqlite::types::Value;
 use rusqlite::{params_from_iter, Connection};

--- a/src/models/block_group_edge.rs
+++ b/src/models/block_group_edge.rs
@@ -1,3 +1,4 @@
+use crate::models::block_group::BlockGroup;
 use crate::models::edge::Edge;
 use rusqlite::types::Value;
 use rusqlite::{params_from_iter, Connection};

--- a/src/models/edge.rs
+++ b/src/models/edge.rs
@@ -471,6 +471,7 @@ impl Edge {
     }
 }
 
+#[cfg(test)]
 mod tests {
     // Note this useful idiom: importing names from outer (for mod tests) scope.
     use super::*;

--- a/src/models/edge.rs
+++ b/src/models/edge.rs
@@ -1,13 +1,15 @@
+use std::collections::{HashMap, HashSet};
+use std::hash::{Hash, RandomState};
+
 use itertools::Itertools;
 use petgraph::graphmap::DiGraphMap;
 use rusqlite::types::Value;
-use rusqlite::{params_from_iter, Connection};
-use std::collections::{HashMap, HashSet};
-use std::hash::RandomState;
+use rusqlite::{params_from_iter, Connection, Result as SQLResult, Row};
+use serde::{Deserialize, Serialize};
 
 use crate::models::{sequence::Sequence, strand::Strand};
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
 pub struct Edge {
     pub id: i32,
     pub source_hash: String,
@@ -32,13 +34,28 @@ pub struct EdgeData {
     pub phased: i32,
 }
 
+impl From<&Edge> for EdgeData {
+    fn from(item: &Edge) -> Self {
+        EdgeData {
+            source_hash: item.source_hash.clone(),
+            source_coordinate: item.source_coordinate,
+            source_strand: item.source_strand,
+            target_hash: item.target_hash.clone(),
+            target_coordinate: item.target_coordinate,
+            target_strand: item.target_strand,
+            chromosome_index: item.chromosome_index,
+            phased: item.phased,
+        }
+    }
+}
+
 #[derive(Eq, Hash, PartialEq)]
 pub struct BlockKey {
     pub sequence_hash: String,
     pub coordinate: i32,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct GroupBlock {
     pub id: i32,
     pub sequence_hash: String,
@@ -114,6 +131,20 @@ impl Edge {
         }
     }
 
+    fn edge_from_row(row: &Row) -> SQLResult<Edge> {
+        Ok(Edge {
+            id: row.get(0)?,
+            source_hash: row.get(1)?,
+            source_coordinate: row.get(2)?,
+            source_strand: row.get(3)?,
+            target_hash: row.get(4)?,
+            target_coordinate: row.get(5)?,
+            target_strand: row.get(6)?,
+            chromosome_index: row.get(7)?,
+            phased: row.get(8)?,
+        })
+    }
+
     pub fn bulk_load(conn: &Connection, edge_ids: &[i32]) -> Vec<Edge> {
         let formatted_edge_ids = edge_ids
             .iter()
@@ -127,19 +158,7 @@ impl Edge {
     pub fn query(conn: &Connection, query: &str, placeholders: Vec<Value>) -> Vec<Edge> {
         let mut stmt = conn.prepare(query).unwrap();
         let rows = stmt
-            .query_map(params_from_iter(placeholders), |row| {
-                Ok(Edge {
-                    id: row.get(0)?,
-                    source_hash: row.get(1)?,
-                    source_coordinate: row.get(2)?,
-                    source_strand: row.get(3)?,
-                    target_hash: row.get(4)?,
-                    target_coordinate: row.get(5)?,
-                    target_strand: row.get(6)?,
-                    chromosome_index: row.get(7)?,
-                    phased: row.get(8)?,
-                })
-            })
+            .query_map(params_from_iter(placeholders), Edge::edge_from_row)
             .unwrap();
         let mut edges = vec![];
         for row in rows {
@@ -150,6 +169,7 @@ impl Edge {
 
     pub fn bulk_create(conn: &Connection, edges: Vec<EdgeData>) -> Vec<i32> {
         let mut edge_rows = vec![];
+        let mut edge_map: HashMap<EdgeData, i32> = HashMap::new();
         for edge in &edges {
             let source_hash = format!("\"{0}\"", edge.source_hash);
             let source_strand = format!("\"{0}\"", edge.source_strand);
@@ -172,11 +192,9 @@ impl Edge {
 
         let select_statement = format!("SELECT * FROM edges WHERE (source_hash, source_coordinate, source_strand, target_hash, target_coordinate, target_strand, chromosome_index, phased) in ({0});", formatted_edge_rows);
         let existing_edges = Edge::query(conn, &select_statement, vec![]);
-        let mut existing_edge_ids: Vec<i32> = existing_edges
-            .clone()
-            .into_iter()
-            .map(|edge| edge.id)
-            .collect();
+        for edge in existing_edges.iter() {
+            edge_map.insert(EdgeData::from(edge), edge.id);
+        }
 
         let existing_edge_set = HashSet::<EdgeData, RandomState>::from_iter(
             existing_edges.into_iter().map(Edge::to_data),
@@ -208,25 +226,23 @@ impl Edge {
             edge_rows_to_insert.push(edge_row);
         }
 
-        if edge_rows_to_insert.is_empty() {
-            return existing_edge_ids;
-        }
+        if !edge_rows_to_insert.is_empty() {
+            for chunk in edge_rows_to_insert.chunks(100000) {
+                let formatted_edge_rows_to_insert = chunk.join(", ");
 
-        for chunk in edge_rows_to_insert.chunks(100000) {
-            let formatted_edge_rows_to_insert = chunk.join(", ");
-
-            let insert_statement = format!("INSERT INTO edges (source_hash, source_coordinate, source_strand, target_hash, target_coordinate, target_strand, chromosome_index, phased) VALUES {0} RETURNING (id);", formatted_edge_rows_to_insert);
-            let mut stmt = conn.prepare(&insert_statement).unwrap();
-            let rows = stmt.query_map([], |row| row.get(0)).unwrap();
-            let mut edge_ids: Vec<i32> = vec![];
-            for row in rows {
-                edge_ids.push(row.unwrap());
+                let insert_statement = format!("INSERT INTO edges (source_hash, source_coordinate, source_strand, target_hash, target_coordinate, target_strand, chromosome_index, phased) VALUES {0} RETURNING *;", formatted_edge_rows_to_insert);
+                let mut stmt = conn.prepare(&insert_statement).unwrap();
+                let rows = stmt.query_map([], Edge::edge_from_row).unwrap();
+                for row in rows {
+                    let edge = row.unwrap();
+                    edge_map.insert(EdgeData::from(&edge), edge.id);
+                }
             }
-
-            existing_edge_ids.extend(edge_ids);
         }
-
-        existing_edge_ids
+        edges
+            .iter()
+            .map(|edge| *edge_map.get(edge).unwrap())
+            .collect::<Vec<i32>>()
     }
 
     pub fn to_data(edge: Edge) -> EdgeData {
@@ -526,6 +542,79 @@ mod tests {
         assert_eq!(edge_result3.source_coordinate, 4);
         assert_eq!(edge_result3.target_hash, Sequence::PATH_END_HASH);
         assert_eq!(edge_result3.target_coordinate, -1);
+    }
+
+    #[test]
+    fn test_bulk_create_returns_edges_in_order() {
+        let conn = &mut get_connection(None);
+        Collection::create(conn, "test collection");
+        let sequence1 = Sequence::new()
+            .sequence_type("DNA")
+            .sequence("ATCGATCG")
+            .save(conn);
+        let edge1 = EdgeData {
+            source_hash: Sequence::PATH_START_HASH.to_string(),
+            source_coordinate: -1,
+            source_strand: Strand::Forward,
+            target_hash: sequence1.hash.clone(),
+            target_coordinate: 1,
+            target_strand: Strand::Forward,
+            chromosome_index: 0,
+            phased: 0,
+        };
+        let sequence2 = Sequence::new()
+            .sequence_type("DNA")
+            .sequence("AAAAAAAA")
+            .save(conn);
+        let edge2 = EdgeData {
+            source_hash: sequence1.hash.clone(),
+            source_coordinate: 2,
+            source_strand: Strand::Forward,
+            target_hash: sequence2.hash.clone(),
+            target_coordinate: 3,
+            target_strand: Strand::Forward,
+            chromosome_index: 0,
+            phased: 0,
+        };
+        let edge3 = EdgeData {
+            source_hash: sequence2.hash.clone(),
+            source_coordinate: 4,
+            source_strand: Strand::Forward,
+            target_hash: Sequence::PATH_END_HASH.to_string(),
+            target_coordinate: -1,
+            target_strand: Strand::Forward,
+            chromosome_index: 0,
+            phased: 0,
+        };
+
+        let edges = vec![edge2.clone(), edge3.clone()];
+        let edge_ids1 = Edge::bulk_create(conn, edges.clone());
+        assert_eq!(edge_ids1.len(), 2);
+        for (index, id) in edge_ids1.iter().enumerate() {
+            let binding = Edge::query(
+                conn,
+                "select * from edges where id = ?1;",
+                vec![Value::from(*id)],
+            );
+            let edge = binding.first().unwrap();
+            assert_eq!(EdgeData::from(edge), edges[index]);
+        }
+
+        let edges = vec![edge1.clone(), edge2.clone(), edge3.clone()];
+        let edge_ids2 = Edge::bulk_create(conn, edges.clone());
+        assert_eq!(edge_ids2[1], edge_ids1[0]);
+        assert_eq!(edge_ids2[2], edge_ids1[1]);
+        assert_eq!(edge_ids2.len(), 3);
+        for (index, id) in edge_ids2.iter().enumerate() {
+            // this sort by makes it so the order will not match the input order of the function call
+            let binding = Edge::query(
+                conn,
+                "select * from edges where id = ?1;",
+                vec![Value::from(*id)],
+            );
+            let edge = binding.first().unwrap();
+            assert_eq!(EdgeData::from(edge), edges[index]);
+        }
     }
 
     #[test]

--- a/src/models/operations.rs
+++ b/src/models/operations.rs
@@ -395,9 +395,7 @@ impl Branch {
     }
 }
 
-pub struct OperationState {
-    operation_id: i32,
-}
+pub struct OperationState {}
 
 impl OperationState {
     pub fn set_operation(conn: &Connection, db_uuid: &str, op_id: i32) {

--- a/src/models/path.rs
+++ b/src/models/path.rs
@@ -68,7 +68,9 @@ pub struct NewBlock {
 
 impl Path {
     pub fn create(conn: &Connection, name: &str, block_group_id: i32, edge_ids: &[i32]) -> Path {
-        // TODO: Should we do something if edge_ids don't match here?
+        // TODO: Should we do something if edge_ids don't match here? Suppose we have a path
+        // for a block group with edges 1,2,3. And then the same path is added again with edges
+        // 5,6,7, should this be an error? Should we just keep adding edges?
         let query = "INSERT INTO path (name, block_group_id) VALUES (?1, ?2) RETURNING (id)";
         let mut stmt = conn.prepare(query).unwrap();
 

--- a/src/models/path.rs
+++ b/src/models/path.rs
@@ -83,7 +83,7 @@ impl Path {
             .unwrap();
         let path = match rows.next().unwrap() {
             Ok(res) => res,
-            Err(rusqlite::Error::SqliteFailure(err, details)) => {
+            Err(rusqlite::Error::SqliteFailure(err, _details)) => {
                 if err.code == rusqlite::ErrorCode::ConstraintViolation {
                     let query = "SELECT id from path where name = ?1 AND block_group_id = ?2;";
                     Path {
@@ -287,6 +287,7 @@ impl Path {
     }
 }
 
+#[cfg(test)]
 mod tests {
     // Note this useful idiom: importing names from outer (for mod tests) scope.
     use super::*;

--- a/src/models/sequence.rs
+++ b/src/models/sequence.rs
@@ -329,6 +329,7 @@ impl Sequence {
     }
 }
 
+#[cfg(test)]
 mod tests {
     use std::path::PathBuf;
     // Note this useful idiom: importing names from outer (for mod tests) scope.

--- a/src/models/sequence.rs
+++ b/src/models/sequence.rs
@@ -2,11 +2,12 @@ use noodles::core::Position;
 use noodles::fasta;
 use rusqlite::types::Value;
 use rusqlite::{params_from_iter, Connection};
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::{fs, str};
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
 pub struct Sequence {
     pub hash: String,
     pub sequence_type: String,
@@ -20,7 +21,7 @@ pub struct Sequence {
     pub external_sequence: bool,
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct NewSequence<'a> {
     sequence_type: Option<&'a str>,
     sequence: Option<&'a str>,
@@ -28,6 +29,17 @@ pub struct NewSequence<'a> {
     file_path: Option<&'a str>,
     length: Option<i32>,
     shallow: bool,
+}
+
+impl<'a> From<&'a Sequence> for NewSequence<'a> {
+    fn from(value: &'a Sequence) -> NewSequence<'a> {
+        NewSequence::new()
+            .sequence_type(&value.sequence_type)
+            .sequence(&value.sequence)
+            .name(&value.name)
+            .file_path(&value.file_path)
+            .length(value.length)
+    }
 }
 
 impl<'a> NewSequence<'a> {
@@ -60,8 +72,10 @@ impl<'a> NewSequence<'a> {
     }
 
     pub fn file_path(mut self, path: &'a str) -> Self {
-        self.file_path = Some(path);
-        self.shallow = true;
+        if !path.is_empty() {
+            self.file_path = Some(path);
+            self.shallow = true;
+        }
         self
     }
 
@@ -76,16 +90,23 @@ impl<'a> NewSequence<'a> {
         hasher.update(";");
         if let Some(v) = self.sequence {
             hasher.update(v);
-            hasher.update(";");
+        } else {
+            hasher.update("");
         }
+        hasher.update(";");
         if let Some(v) = self.name {
             hasher.update(v);
-            hasher.update(";");
+        } else {
+            hasher.update("");
         }
+        hasher.update(";");
         if let Some(v) = self.file_path {
             hasher.update(v);
-            hasher.update(";");
+        } else {
+            hasher.update("");
         }
+        hasher.update(";");
+
         format!("{:x}", hasher.finalize())
     }
 

--- a/src/models/strand.rs
+++ b/src/models/strand.rs
@@ -1,8 +1,9 @@
 use rusqlite::types::{FromSql, FromSqlResult, ToSqlOutput, Value, ValueRef};
 use rusqlite::ToSql;
+use serde::{Deserialize, Serialize};
 use std::fmt;
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub enum Strand {
     Forward,
     Reverse,

--- a/src/operation_management.rs
+++ b/src/operation_management.rs
@@ -23,6 +23,14 @@ use crate::models::sample::Sample;
 use crate::models::sequence::{NewSequence, Sequence};
 use crate::models::strand::Strand;
 
+/* General information
+
+Changesets from sqlite will be created in the order that operations are applied in the database,
+so given our foreign key setup, we would not expect out of order table/row creation. i.e. block
+groups will always appear before block group edges, etc.
+
+ */
+
 pub enum FileMode {
     Read,
     Write,

--- a/src/updates/vcf.rs
+++ b/src/updates/vcf.rs
@@ -324,8 +324,6 @@ mod tests {
     use std::collections::HashSet;
     use std::path::PathBuf;
 
-    // NOTE: Ignoring this test until we've figured out a good way to handle homozygous cases
-    #[ignore]
     #[test]
     fn test_update_fasta_with_vcf() {
         setup_gen_dir();


### PR DESCRIPTION
This is an extension to the changeset management to identify dependencies of a changeset and write those out. On imports, we ensure that the ids of dependent entities are created or retrieved from the current checked out database.

The workflow this handles is suppose we have branch A with operations 1->2->3, and branch B with operations 1->4->5. If we apply operation 3, things required from operation 2 may not be present. This ensures they will be. For the reversion, we create a new commit with the updates from this application (similar to a new commit id resulting from a cherry-pick).