### PR TITLE
Cache fasta index for external sequence lookup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,6 +233,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "cached"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4d73155ae6b28cf5de4cfc29aeb02b8a1c6dab883cb015d15cd514e42766846"
+dependencies = [
+ "ahash",
+ "cached_proc_macro",
+ "cached_proc_macro_types",
+ "hashbrown",
+ "once_cell",
+ "thiserror",
+ "web-time",
+]
+
+[[package]]
+name = "cached_proc_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f42a145ed2d10dce2191e1dcf30cfccfea9026660e143662ba5eec4017d5daa"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "cached_proc_macro_types"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
+
+[[package]]
 name = "cc"
 version = "1.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,6 +429,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,6 +528,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fuchsia-cprng"
@@ -530,6 +610,7 @@ dependencies = [
 name = "gen"
 version = "0.1.0"
 dependencies = [
+ "cached",
  "chrono",
  "clap",
  "fallible-streaming-iterator",
@@ -599,6 +680,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
+ "allocator-api2",
 ]
 
 [[package]]
@@ -638,6 +720,12 @@ checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "include_dir"
@@ -1480,6 +1568,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tokio"
 version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1593,6 +1701,16 @@ name = "wasm-bindgen-shared"
 version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,11 @@ rusqlite = { version = "0.31.0", features = ["bundled", "array", "session"] }
 rusqlite_migration = { version = "1.2.0" , features = ["from-directory"]}
 sha2 = "0.10.8"
 tempfile = "3.12.0"
-noodles = { version = "0.78.0", features = ["core", "vcf", "fasta", "async"] }
+noodles = { version = "0.78.0", features = ["bgzf", "core", "vcf", "fasta", "async"] }
 petgraph = "0.6.5"
 chrono = "0.4.38"
 tempdir = "0.3.7"
 fallible-streaming-iterator = "0.1.9"
 serde = {  version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.128"
+cached = "0.53.1"

--- a/src/imports/fasta.rs
+++ b/src/imports/fasta.rs
@@ -62,6 +62,7 @@ pub fn import_fasta(
                 .sequence_type("DNA")
                 .name(&name)
                 .file_path(fasta)
+                .length(sequence_length)
                 .save(conn)
         } else {
             Sequence::new()
@@ -132,6 +133,35 @@ mod tests {
             &fasta_path.to_str().unwrap().to_string(),
             "test",
             false,
+            &conn,
+            op_conn,
+        );
+        assert_eq!(
+            BlockGroup::get_all_sequences(&conn, 1),
+            HashSet::from_iter(vec!["ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()])
+        );
+
+        let path = Path::get(&conn, 1);
+        assert_eq!(
+            Path::sequence(&conn, path),
+            "ATCGATCGATCGATCGATCGGGAACACACAGAGA".to_string()
+        );
+    }
+
+    #[test]
+    fn test_add_fasta_shallow() {
+        setup_gen_dir();
+        let mut fasta_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        fasta_path.push("fixtures/simple.fa");
+        let conn = get_connection(None);
+        let db_uuid = metadata::get_db_uuid(&conn);
+        let op_conn = &get_operation_connection(None);
+        setup_db(op_conn, &db_uuid);
+
+        import_fasta(
+            &fasta_path.to_str().unwrap().to_string(),
+            "test",
+            true,
             &conn,
             op_conn,
         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -175,8 +175,6 @@ fn main() {
     let conn = get_connection(db);
     let db_uuid = metadata::get_db_uuid(&conn);
 
-    let default_collection = get_default_collection(&operation_conn);
-
     // initialize the selected database if needed.
     setup_db(&operation_conn, &db_uuid);
 
@@ -189,7 +187,8 @@ fn main() {
         }) => {
             conn.execute("BEGIN TRANSACTION", []).unwrap();
             let name = &name.clone().unwrap_or_else(|| {
-                default_collection.expect("No collection specified and default not setup.")
+                get_default_collection(&operation_conn)
+                    .expect("No collection specified and default not setup.")
             });
             if fasta.is_some() {
                 import_fasta(
@@ -217,7 +216,8 @@ fn main() {
         }) => {
             conn.execute("BEGIN TRANSACTION", []).unwrap();
             let name = &name.clone().unwrap_or_else(|| {
-                default_collection.expect("No collection specified and default not setup.")
+                get_default_collection(&operation_conn)
+                    .expect("No collection specified and default not setup.")
             });
             update_with_vcf(
                 vcf,
@@ -345,7 +345,8 @@ fn main() {
         }
         Some(Commands::Export { name, gfa }) => {
             let name = &name.clone().unwrap_or_else(|| {
-                default_collection.expect("No collection specified and default not setup.")
+                get_default_collection(&operation_conn)
+                    .expect("No collection specified and default not setup.")
             });
             conn.execute("BEGIN TRANSACTION", []).unwrap();
             export_gfa(&conn, name, &PathBuf::from(gfa));

--- a/src/models/edge.rs
+++ b/src/models/edge.rs
@@ -315,7 +315,9 @@ impl Edge {
         let mut blocks = vec![];
         let mut block_index = 0;
         let mut boundary_edges = vec![];
-        for (hash, sequence) in sequences_by_hash.into_iter() {
+        // we sort by keys to exploit the external sequence cache which keeps the most recently used
+        // external sequence in memory.
+        for (hash, sequence) in sequences_by_hash.iter().sorted_by_key(|k| k.0) {
             let block_boundaries = Edge::get_block_boundaries(
                 edges_by_source_hash.get(hash.as_str()),
                 edges_by_target_hash.get(hash.as_str()),

--- a/src/models/sequence.rs
+++ b/src/models/sequence.rs
@@ -7,7 +7,6 @@ use rusqlite::{params_from_iter, Connection};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
-use std::path::PathBuf;
 use std::{fs, str};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
@@ -276,7 +275,7 @@ impl Sequence {
 
         let start: Option<i32> = start.into();
         let end: Option<i32> = end.into();
-        let mut start = start.unwrap_or(0) as usize;
+        let start = start.unwrap_or(0) as usize;
         let end = end.unwrap_or(self.length) as usize;
         if self.external_sequence {
             let file_path = self.file_path.clone();

--- a/src/models/sequence.rs
+++ b/src/models/sequence.rs
@@ -238,15 +238,13 @@ impl Sequence {
             start += 1;
 
             if let Some(index) = fasta_index(&file_path) {
+                let builder = IndexBuilder::default().set_index(index);
                 if let Some(gzi_index) = fasta_gzi_index(&file_path) {
                     let bgzf_reader = bgzf::indexed_reader::Builder::default()
                         .set_index(gzi_index)
                         .build_from_path(&file_path)
                         .unwrap();
-                    let mut reader = fasta::indexed_reader::Builder::default()
-                        .set_index(index)
-                        .build_from_reader(bgzf_reader)
-                        .unwrap();
+                    let mut reader = builder.build_from_reader(bgzf_reader).unwrap();
                     sequence = Some(
                         str::from_utf8(
                             reader
@@ -260,10 +258,7 @@ impl Sequence {
                     );
                 } else {
                     // noodles reader query is 1 based, inclusive
-                    let mut reader = IndexBuilder::default()
-                        .set_index(index)
-                        .build_from_path(&file_path)
-                        .unwrap();
+                    let mut reader = builder.build_from_path(&file_path).unwrap();
                     sequence = Some(
                         str::from_utf8(
                             reader

--- a/src/updates/vcf.rs
+++ b/src/updates/vcf.rs
@@ -290,9 +290,6 @@ pub fn update_with_vcf(
                 .entry((vcf_entry.path, vcf_entry.sample_name))
                 .or_default()
                 .push(change);
-            if changes.len() % 10000 == 0 {
-                println!("{v} changes done", v = changes.len());
-            }
         }
     }
     let mut summary: HashMap<String, HashMap<String, i32>> = HashMap::new();

--- a/src/updates/vcf.rs
+++ b/src/updates/vcf.rs
@@ -290,6 +290,9 @@ pub fn update_with_vcf(
                 .entry((vcf_entry.path, vcf_entry.sample_name))
                 .or_default()
                 .push(change);
+            if changes.len() % 10000 == 0 {
+                println!("{v} changes done", v = changes.len());
+            }
         }
     }
     let mut summary: HashMap<String, HashMap<String, i32>> = HashMap::new();


### PR DESCRIPTION
Caches the index file so it doesn't need to be read everytime for external sequence lookup.