### PR TITLE
Optimizations for gfa export

### DIFF
--- a/src/exports/gfa.rs
+++ b/src/exports/gfa.rs
@@ -42,22 +42,22 @@ pub fn export_gfa(conn: &Connection, collection_name: &str, filename: &PathBuf) 
         }
     }
 
-    write_segments(&mut writer, blocks.clone(), terminal_block_ids.clone());
+    write_segments(&mut writer, &blocks, &terminal_block_ids);
     write_links(
         &mut writer,
-        graph,
-        edges_by_node_pair.clone(),
-        terminal_block_ids,
+        &graph,
+        &edges_by_node_pair,
+        &terminal_block_ids,
     );
     write_paths(&mut writer, conn, collection_name, &blocks);
 }
 
 fn write_segments(
     writer: &mut BufWriter<File>,
-    blocks: Vec<GroupBlock>,
-    terminal_block_ids: HashSet<i32>,
+    blocks: &Vec<GroupBlock>,
+    terminal_block_ids: &HashSet<i32>,
 ) {
-    for block in &blocks {
+    for block in blocks {
         if terminal_block_ids.contains(&block.id) {
             continue;
         }
@@ -78,9 +78,9 @@ fn segment_line(sequence: &str, index: usize) -> String {
 
 fn write_links(
     writer: &mut BufWriter<File>,
-    graph: DiGraphMap<i32, ()>,
-    edges_by_node_pair: HashMap<(i32, i32), Edge>,
-    terminal_block_ids: HashSet<i32>,
+    graph: &DiGraphMap<i32, ()>,
+    edges_by_node_pair: &HashMap<(i32, i32), Edge>,
+    terminal_block_ids: &HashSet<i32>,
 ) {
     for (source, target, ()) in graph.all_edges() {
         if terminal_block_ids.contains(&source) || terminal_block_ids.contains(&target) {

--- a/src/models/edge.rs
+++ b/src/models/edge.rs
@@ -343,22 +343,20 @@ impl Edge {
             if !block_boundaries.is_empty() {
                 let start = 0;
                 let end = block_boundaries[0];
-                let block_sequence = sequence.get_sequence(start, end).to_string();
                 let first_block = GroupBlock {
                     id: block_index,
                     node_id: *node_id,
-                    sequence: block_sequence,
+                    sequence: sequence.get_sequence(start, end),
                     start,
                     end,
                 };
                 blocks.push(first_block);
                 block_index += 1;
                 for (start, end) in block_boundaries.clone().into_iter().tuple_windows() {
-                    let block_sequence = sequence.get_sequence(start, end).to_string();
                     let block = GroupBlock {
                         id: block_index,
                         node_id: *node_id,
-                        sequence: block_sequence,
+                        sequence: sequence.get_sequence(start, end),
                         start,
                         end,
                     };
@@ -367,11 +365,10 @@ impl Edge {
                 }
                 let start = block_boundaries[block_boundaries.len() - 1];
                 let end = sequence.length;
-                let block_sequence = sequence.get_sequence(start, end).to_string();
                 let last_block = GroupBlock {
                     id: block_index,
                     node_id: *node_id,
-                    sequence: block_sequence,
+                    sequence: sequence.get_sequence(start, end),
                     start,
                     end,
                 };


### PR DESCRIPTION
A few changes i needed to make for exporting hg38 to a gfa. The memory use is still bad from the block creation though. I think we need to have a streaming method for `Edge::blocks_from_edges` or maybe a version that defers sequence fetching to the caller.