### PR TITLE
GFA export improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,25 +418,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,7 +642,6 @@ dependencies = [
  "chrono",
  "clap",
  "fallible-streaming-iterator",
- "gfa-reader",
  "include_dir",
  "intervaltree",
  "itertools 0.13.0",
@@ -686,28 +666,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
-name = "gfa-reader"
-version = "0.1.4"
-source = "git+https://github.com/MoinSebi/gfa-reader?rev=9db57c80e34eb137c1d641eabe513101e0de5955#9db57c80e34eb137c1d641eabe513101e0de5955"
-dependencies = [
- "flate2",
- "memmap2",
- "rand 0.8.5",
- "rayon",
 ]
 
 [[package]]
@@ -1061,15 +1019,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
-name = "memmap2"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1384,15 +1333,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1424,27 +1364,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1458,35 +1377,6 @@ name = "rand_core"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom",
-]
-
-[[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
 
 [[package]]
 name = "rdrand"
@@ -1704,7 +1594,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 dependencies = [
- "rand 0.4.6",
+ "rand",
  "remove_dir_all 0.5.3",
 ]
 
@@ -1794,12 +1684,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
@@ -1994,7 +1878,6 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "byteorder",
  "zerocopy-derive",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ cached = "0.53.1"
 chrono = "0.4.38"
 clap = { version = "4.5.8", features = ["derive"] }
 fallible-streaming-iterator = "0.1.9"
-gfa-reader = { git = "https://github.com/MoinSebi/gfa-reader", rev = "9db57c80e34eb137c1d641eabe513101e0de5955" }
 include_dir = "0.7.4"
 intervaltree = "0.2.7"
 itertools = "0.13.0"

--- a/src/gfa_reader.rs
+++ b/src/gfa_reader.rs
@@ -1,3 +1,27 @@
+// This file copied from https://github.com/MoinSebi/gfa-reader
+
+// MIT License
+
+// Copyright (c) 2023 Sebastian Vorbrugg
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 use std::fs::File;
 use std::io::{prelude::*, BufReader};
 

--- a/src/gfa_reader.rs
+++ b/src/gfa_reader.rs
@@ -1,0 +1,701 @@
+use std::fs::File;
+use std::io::{prelude::*, BufReader};
+
+use std::path::Path as file_path;
+
+#[derive(Debug, Clone, Default, Ord, PartialEq, Eq, PartialOrd)]
+/// GFA header line
+/// This line begins with an 'H'
+pub struct Header {
+    pub tag: String,
+    pub typ: String,
+    pub version_number: String,
+}
+
+impl Header {
+    /// Parse header from string (H-line)
+    fn from_string(line: &str) -> Header {
+        let line = line.split_whitespace().nth(1).unwrap();
+        let tag = line.split(':').nth(0).unwrap().to_string();
+        let typ = line.split(':').nth(1).unwrap().to_string();
+        let version_number = line.split(':').nth(2).unwrap().to_string();
+        Header {
+            tag,
+            typ,
+            version_number,
+        }
+    }
+}
+
+/// Possible generics which can be used as identifier
+pub trait SampleType {
+    /// Parse a string to a generic type
+    ///
+    /// Might use a String to add the relevant data
+    fn parse1(input: &str, s: &mut String) -> Self;
+}
+
+impl SampleType for String {
+    fn parse1(input: &str, _s: &mut String) -> Self {
+        input.to_string()
+    }
+}
+
+impl SampleType for usize {
+    fn parse1(input: &str, _s: &mut String) -> Self {
+        input.parse().unwrap()
+    }
+}
+
+impl SampleType for u64 {
+    fn parse1(input: &str, _s: &mut String) -> Self {
+        input.parse().unwrap()
+    }
+}
+impl SampleType for u32 {
+    fn parse1(input: &str, _s: &mut String) -> Self {
+        input.parse().unwrap()
+    }
+}
+
+impl SampleType for SeqIndex {
+    fn parse1(input: &str, s: &mut String) -> Self {
+        s.push_str(input);
+        Self([s.len() - input.len(), s.len()])
+    }
+}
+
+/// Optional fields
+///
+/// In addition, used for Overlap fields in the graph
+pub trait Opt {
+    fn parse1(input: Option<&str>, s: &mut String) -> Self;
+}
+
+impl Opt for () {
+    fn parse1(_input: Option<&str>, _s: &mut String) -> Self {}
+}
+
+impl Opt for SeqIndex {
+    fn parse1(input: Option<&str>, s: &mut String) -> Self {
+        if input.is_none() {
+            SeqIndex([0, 0])
+        } else {
+            let input = input.unwrap();
+            s.push_str(input);
+            Self([s.len() - input.len(), s.len()])
+        }
+    }
+}
+
+///  Start position and end position of a sequence
+///
+/// Similar to a slice
+/// Can be sued to get sequence and len
+#[derive(Debug, Clone, Ord, Eq, PartialOrd, PartialEq)]
+pub struct SeqIndex([usize; 2]);
+
+impl SeqIndex {
+    fn parse1(input: &str, s: &mut String) -> Self {
+        s.push_str(input);
+        Self([s.len() - input.len(), s.len()])
+    }
+
+    pub fn get_string<'a>(&self, s: &'a str) -> &'a str {
+        &s[self.0[0]..self.0[1]]
+    }
+
+    pub fn get_len(&self) -> usize {
+        self.0[1] - self.0[0]
+    }
+}
+
+/// GFA segment
+#[derive(Debug, Clone, Ord, Eq, PartialOrd, PartialEq)]
+pub struct Segment<T: SampleType + Ord, S: Opt + Ord> {
+    pub id: T,
+    pub sequence: SeqIndex,
+    pub length: u32,
+    pub opt: S,
+}
+
+/// GFA link
+#[derive(Debug, Clone, Ord, Eq, PartialOrd, PartialEq)]
+pub struct Link<T: SampleType, S: Opt, U: Opt> {
+    pub from: T,
+    pub from_dir: bool,
+    pub to: T,
+    pub to_dir: bool,
+    pub overlap: U,
+    pub opt: S,
+}
+
+/// GFA Path
+#[derive(Debug, Clone, Ord, Eq, PartialOrd, PartialEq)]
+pub struct Path<T: SampleType, S: Opt, U: Opt> {
+    pub name: String,
+    pub dir: Vec<bool>,
+    pub nodes: Vec<T>,
+    pub overlap: U,
+    pub opt: S,
+}
+
+/// GFA Walk
+#[derive(Debug, Clone, Ord, Eq, PartialOrd, PartialEq)]
+pub struct Walk<T: SampleType, S: Opt> {
+    pub sample_id: String,
+    pub hap_index: u32,
+    pub seq_id: String,
+    pub seq_start: i32,
+    pub seq_end: i32,
+    pub walk_dir: Vec<bool>,
+    pub walk_id: Vec<T>,
+    pub opt: S,
+}
+
+/// GFA Containment
+#[derive(Debug, Clone, Ord, Eq, PartialOrd, PartialEq)]
+pub struct Containment<T: SampleType, S: Opt> {
+    pub container: T,
+    pub container_dir: bool,
+    pub contained: T,
+    pub contained_dir: bool,
+    pub pos: u32,
+    pub overlap: SeqIndex,
+    pub opt: S,
+}
+
+/// GFA Jump
+#[derive(Debug, Clone, Ord, Eq, PartialOrd, PartialEq)]
+pub struct Jump<T: SampleType, S: Opt> {
+    pub from: T,
+    pub from_dir: bool,
+    pub to: T,
+    pub to_dir: bool,
+    pub distance: i64,
+    pub opt: S,
+}
+
+/// Gfa struct
+#[derive(Debug, Clone, Ord, Eq, PartialOrd, PartialEq)]
+pub struct Gfa<T: SampleType + Ord, S: Opt + Ord, U: Opt> {
+    pub header: Header,
+    pub segments: Vec<Segment<T, S>>,
+    pub links: Vec<Link<T, S, U>>,
+    pub paths: Vec<Path<T, S, U>>,
+    pub jump: Vec<Jump<T, S>>,
+    pub containment: Vec<Containment<T, S>>,
+    pub walk: Vec<Walk<T, S>>,
+
+    pub sequence: String,
+}
+
+impl<T: SampleType + Ord + Clone, S: Opt + Ord + Clone, U: Opt> Default for Gfa<T, S, U> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T: SampleType + Ord + Clone, S: Opt + Ord + Clone, U: Opt> Gfa<T, S, U> {
+    pub fn new() -> Self {
+        Self {
+            header: Header::default(),
+            segments: Vec::new(),
+            sequence: String::new(),
+            links: Vec::new(),
+            paths: Vec::new(),
+            jump: Vec::new(),
+            containment: Vec::new(),
+            walk: Vec::new(),
+        }
+    }
+
+    /// Parse a GFA file
+    pub fn parse_gfa_file(file_name: &str) -> Gfa<T, S, U> {
+        if file_path::new(file_name).exists() {
+            println!("Reading file: {}", file_name);
+            let file = File::open(file_name).expect("ERROR: CAN NOT READ FILE\n");
+            let reader = BufReader::new(file);
+
+            let version_number = get_version(file_name);
+            let mut z: Gfa<T, S, U> = Gfa::new();
+
+            // Iterate over lines
+            for line in reader.lines() {
+                let line_string = line.unwrap();
+                let mut split_line = line_string.split_whitespace();
+                match split_line.next().unwrap() {
+                    "S" => {
+                        let name = split_line.next().unwrap();
+                        if version_number < 2.0 {
+                            let sequence = split_line.next().unwrap();
+                            let size = sequence.len() as u32;
+                            let opt = split_line.next();
+                            z.segments.push(Segment {
+                                id: T::parse1(name, &mut z.sequence),
+                                sequence: SeqIndex::parse1(sequence, &mut z.sequence),
+                                length: size,
+                                opt: S::parse1(opt, &mut z.sequence),
+                            });
+                        } else {
+                            let sequence = split_line.next().unwrap();
+                            let size = split_line.next().unwrap().parse().unwrap();
+                            let opt = split_line.next();
+
+                            z.segments.push(Segment {
+                                id: T::parse1(name, &mut z.sequence),
+                                sequence: SeqIndex::parse1(sequence, &mut z.sequence),
+                                length: size,
+                                opt: S::parse1(opt, &mut z.sequence),
+                            });
+                        }
+                    }
+                    "H" => {
+                        let header = Header::from_string(&line_string);
+                        z.header = header;
+                    }
+                    "L" => {
+                        let from = split_line.next().unwrap();
+                        let from_dir = split_line.next().unwrap() == "+";
+                        let to = split_line.next().unwrap();
+                        let to_dir = split_line.next().unwrap() == "+";
+                        let overlap = split_line.next();
+                        let opt = split_line.next();
+                        z.links.push(Link {
+                            from: T::parse1(from, &mut z.sequence),
+                            from_dir,
+                            to: T::parse1(to, &mut z.sequence),
+                            to_dir,
+                            overlap: U::parse1(overlap, &mut z.sequence),
+                            opt: S::parse1(opt, &mut z.sequence),
+                        });
+                    }
+                    "P" => {
+                        let name = split_line.next().unwrap().to_string();
+                        let (dirs, node_id) =
+                            path_parser(split_line.next().unwrap(), &mut z.sequence);
+                        let overlap = split_line.next();
+                        z.paths.push(Path {
+                            name,
+                            dir: dirs,
+                            nodes: node_id,
+                            overlap: U::parse1(overlap, &mut z.sequence),
+                            opt: S::parse1(split_line.next(), &mut z.sequence),
+                        });
+                    }
+                    "W" => {
+                        let sample_id = split_line.next().unwrap().to_string();
+                        let hap_index = split_line.next().unwrap().parse().unwrap();
+                        let seq_id = split_line.next().unwrap().to_string();
+                        let seq_start = split_line.next().unwrap().parse().unwrap();
+                        let seq_end = split_line.next().unwrap().parse().unwrap();
+                        let (w1, w2) = walk_parser(split_line.next().unwrap(), &mut z.sequence);
+                        let opt = split_line.next();
+                        z.walk.push(Walk {
+                            sample_id,
+                            hap_index,
+                            seq_id,
+                            seq_start,
+                            seq_end,
+                            walk_dir: w1,
+                            walk_id: w2,
+                            opt: S::parse1(opt, &mut z.sequence),
+                        });
+                    }
+                    "C" => {
+                        let container = split_line.next().unwrap();
+                        let container_dir = split_line.next().unwrap() == "+";
+                        let contained = split_line.next().unwrap();
+                        let contained_dir = split_line.next().unwrap() == "+";
+                        let pos = split_line.next().unwrap().parse().unwrap();
+                        let overlap = split_line.next().unwrap();
+                        let opt = split_line.next();
+                        z.containment.push(Containment {
+                            container: T::parse1(container, &mut z.sequence),
+                            container_dir,
+                            contained: T::parse1(contained, &mut z.sequence),
+                            contained_dir,
+                            pos,
+                            overlap: SeqIndex::parse1(overlap, &mut z.sequence),
+                            opt: S::parse1(opt, &mut z.sequence),
+                        });
+                    }
+                    "J" => {
+                        let from = split_line.next().unwrap();
+                        let from_dir = split_line.next().unwrap() == "+";
+                        let to = split_line.next().unwrap();
+                        let to_dir = split_line.next().unwrap() == "+";
+                        let distance = parse_dumb(split_line.next().unwrap());
+                        let opt = split_line.next();
+                        z.jump.push(Jump {
+                            from: T::parse1(from, &mut z.sequence),
+                            from_dir,
+                            to: T::parse1(to, &mut z.sequence),
+                            to_dir,
+                            distance,
+                            opt: S::parse1(opt, &mut z.sequence),
+                        });
+                    }
+                    _ => {}
+                }
+            }
+            z.segments.sort_by(|a, b| a.id.cmp(&b.id));
+            z
+        } else {
+            Gfa::new()
+        }
+    }
+
+    /// Convert Walk to Path
+    pub fn walk_to_path(&mut self, sep: &str) {
+        for walk in self.walk.iter() {
+            self.paths.push(Path {
+                name: walk.sample_id.clone()
+                    + sep
+                    + &walk.hap_index.to_string()
+                    + sep
+                    + &walk.seq_id.clone()
+                    + ":"
+                    + &walk.seq_start.to_string()
+                    + "-"
+                    + &walk.seq_end.to_string(),
+                dir: walk.walk_dir.clone(),
+                nodes: walk.walk_id.to_vec(),
+                overlap: U::parse1(None, &mut self.sequence),
+                opt: walk.opt.clone(),
+            });
+        }
+        self.walk = Vec::new();
+    }
+
+    /// Not 100%, but still okay
+    ///
+    /// Does not work with String and SeqIndex
+    pub fn is_compact(&self) -> bool {
+        self.segments[0].id == T::parse1("1", &mut String::new())
+            && self.segments[self.segments.len() - 1].id
+                == T::parse1(&self.segments.len().to_string(), &mut String::new())
+    }
+
+    /// Get node by id
+    ///
+    /// Using binary search
+    pub fn get_node_by_id(&self, id: &T) -> &Segment<T, S> {
+        &self.segments[self.segments.binary_search_by(|x| x.id.cmp(id)).unwrap()]
+    }
+}
+
+impl Gfa<u32, (), ()> {
+    pub fn get_ind(&self, id: u32) -> &Segment<u32, ()> {
+        &self.segments[self.segments.binary_search_by(|x| x.id.cmp(&id)).unwrap()]
+    }
+}
+
+/// Get the version of a GFA file
+pub fn get_version(file_name: &str) -> f32 {
+    let file = File::open(file_name).expect("ERROR: CAN NOT READ FILE\n");
+    let reader = BufReader::new(file);
+    let mut version_number = 0.0;
+    for line in reader.lines() {
+        let l = line.unwrap();
+        if l.starts_with('H') {
+            let a = l.split_whitespace().nth(1).unwrap();
+            version_number = a.split(':').nth(2).unwrap().parse().unwrap();
+            break;
+        }
+    }
+    version_number
+}
+
+/// Check if a gfa file only contains of numeric segments
+pub fn check_numeric_gfafile(file_name: &str) -> bool {
+    let file = File::open(file_name).expect("ERROR: CAN NOT READ FILE\n");
+    let reader = BufReader::new(file);
+
+    for line in reader.lines() {
+        let l = line.unwrap();
+        if l.starts_with('S') {
+            let a = l.split_whitespace().nth(1).unwrap();
+            if a.parse::<u64>().is_err() {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+/// Check if a gfa file only contains of numeric segments and is compact
+pub fn check_numeric_compact_gfafile(file_name: &str) -> (bool, bool) {
+    let file = File::open(file_name).expect("ERROR: CAN NOT READ FILE\n");
+    let reader = BufReader::new(file);
+    let mut p = Vec::new();
+    for line in reader.lines() {
+        let l = line.unwrap();
+        if l.starts_with('S') {
+            let a = l.split_whitespace().nth(1).unwrap();
+            if a.parse::<u64>().is_err() {
+                return (false, false);
+            } else {
+                p.push(a.parse::<u64>().unwrap());
+            }
+        }
+    }
+    p.sort();
+    if p[0] == 1 && p[p.len() - 1] == p.len() as u64 {
+        (true, true)
+    } else {
+        (true, false)
+    }
+}
+
+/// Parse a path
+///
+/// Separate node and direction with a comma
+fn path_parser<T: SampleType>(path: &str, s: &mut String) -> (Vec<bool>, Vec<T>) {
+    let a = path.split(',');
+    let (mut dirs, mut node_id) = (
+        Vec::with_capacity(a.clone().count()),
+        Vec::with_capacity(a.clone().count()),
+    );
+    for d in a {
+        dirs.push(&d[d.len() - 1..] == "+");
+        node_id.push(SampleType::parse1(&d[..d.len() - 1], s));
+    }
+    (dirs, node_id)
+}
+
+/// Parse a walk
+fn walk_parser<T: SampleType>(walk: &str, s1: &mut String) -> (Vec<bool>, Vec<T>) {
+    let a = walk[1..].split(['<', '>']).count();
+    let (mut dirs, mut node_id) = (Vec::with_capacity(a), Vec::with_capacity(a));
+    dirs.push(walk.starts_with('>'));
+    let mut s = String::new();
+    for x in walk[1..].chars() {
+        if x == '<' || x == '>' {
+            dirs.push(x == '>');
+            node_id.push(T::parse1(&s, s1));
+            s = String::new();
+        } else {
+            s.push(x);
+        }
+    }
+    node_id.push(T::parse1(&s, s1));
+
+    (dirs, node_id)
+}
+
+pub fn fill_nodes(graph: &mut Gfa<u32, (), ()>) {
+    graph.segments.sort();
+
+    let mut filled_vec = Vec::new();
+    let mut prev_value = graph.segments[0].id;
+
+    // Iterate through the sorted vector and find missing values
+    for value in graph.segments.iter() {
+        // Check if there are missing values between previous value and current value
+        if value.id > prev_value + 1 {
+            // Insert missing values
+            for missing_value in prev_value + 1..value.id {
+                filled_vec.push(Segment {
+                    id: missing_value,
+                    sequence: SeqIndex([0, 0]),
+                    length: 0,
+                    opt: (),
+                });
+            }
+        }
+        filled_vec.push(Segment {
+            id: value.id,
+            sequence: value.sequence.clone(),
+            length: value.length,
+            opt: (),
+        });
+        prev_value = value.id;
+    }
+    graph.segments = filled_vec;
+}
+
+/// Parse a string to a generic type
+///
+/// Only needed for Jumps
+fn parse_dumb(s: &str) -> i64 {
+    if s == "*" {
+        -1
+    } else {
+        s.parse().unwrap()
+    }
+}
+
+#[derive(Debug, Clone)]
+/// PanSN-spec path data structure
+/// PanSN-spec
+/// [sample_name][delim][haplotype_id][delim][contig_or_scaffold_name]
+pub struct Pansn<'a, T: SampleType, S: Opt, U: Opt> {
+    pub genomes: Vec<Sample<'a, T, S, U>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Sample<'a, T: SampleType, S: Opt, U: Opt> {
+    pub name: String,
+    pub haplotypes: Vec<Haplotype<'a, T, S, U>>,
+}
+
+#[derive(Debug, Clone)]
+/// PanSN-spec haplotype
+///
+/// Merging multiple paths together
+pub struct Haplotype<'a, T: SampleType, S: Opt, U: Opt> {
+    pub name: String,
+    pub paths: Vec<&'a Path<T, S, U>>,
+}
+impl<'a, T: SampleType, S: Opt, U: Opt> Default for Pansn<'a, T, S, U> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<'a, T: SampleType, S: Opt, U: Opt> Pansn<'a, T, S, U> {
+    pub fn new() -> Self {
+        Self {
+            genomes: Vec::new(),
+        }
+    }
+
+    /// Create Pansn from a list of paths
+    /// ```
+    /// ```
+    pub fn from_graph(paths: &'a [Path<T, S, U>], del: &str) -> Self {
+        let mut genomes: Vec<Sample<'a, T, S, U>> = Vec::new();
+
+        // All path names
+        let a: Vec<String> = paths.iter().map(|x| x.name.to_string()).collect();
+
+        // Check if all path names are in Pansn-spec
+        let b = a
+            .iter()
+            .map(|x| x.split(del).collect::<Vec<&str>>().len())
+            .collect::<Vec<usize>>()
+            .iter()
+            .all(|&x| x == 3);
+
+        // If no del -> one path is one haplotype, is one genome
+        if del == " " || !b {
+            for path in paths.iter() {
+                genomes.push(Sample {
+                    name: path.name.to_string(),
+                    haplotypes: vec![Haplotype {
+                        name: path.name.to_string(),
+                        paths: vec![path],
+                    }],
+                })
+            }
+        } else {
+            for path in paths.iter() {
+                let name_split: Vec<&str> = path.name.split(del).collect();
+                let genome;
+                let haplotype;
+                if name_split.len() > 1 {
+                    genome = name_split[0].to_string();
+                    haplotype = name_split[1].to_string();
+                } else {
+                    genomes.push(Sample {
+                        name: path.name.to_string(),
+                        haplotypes: vec![Haplotype {
+                            name: path.name.to_string(),
+                            paths: vec![path],
+                        }],
+                    });
+                    panic!("No Pansn, remove sep or adjust gfa")
+                }
+                // Gibt es schon so ein Genome?
+                if let Some((index1, _)) = genomes
+                    .iter()
+                    .enumerate()
+                    .find(|(_, item)| item.name == genome)
+                {
+                    let genome = &mut genomes[index1];
+                    // Gibt es schon ein Haplotype
+                    if let Some((index2, _)) = genome
+                        .haplotypes
+                        .iter()
+                        .enumerate()
+                        .find(|(_, item)| item.name == haplotype)
+                    {
+                        let haplo = &mut genome.haplotypes[index2];
+                        haplo.paths.push(path);
+                    } else {
+                        let haplo = Haplotype {
+                            name: haplotype,
+                            paths: vec![path],
+                        };
+                        genome.haplotypes.push(haplo);
+                    }
+                } else {
+                    let haplo = Haplotype {
+                        name: haplotype,
+                        paths: vec![path],
+                    };
+                    let genome = Sample {
+                        name: genome,
+                        haplotypes: vec![haplo],
+                    };
+                    genomes.push(genome);
+                }
+            }
+        }
+        Pansn { genomes }
+    }
+
+    /// Get path for each haplotype
+    #[allow(clippy::type_complexity)]
+    pub fn get_haplo_path(&self) -> Vec<(String, Vec<&Path<T, S, U>>)> {
+        let mut result = Vec::new();
+        for x in self.genomes.iter() {
+            for y in x.haplotypes.iter() {
+                let kk: Vec<_> = y.paths.to_vec();
+                result.push((x.name.clone() + "#" + &y.name, kk));
+            }
+        }
+
+        result
+    }
+
+    /// Get path for each genome
+    #[allow(clippy::type_complexity)]
+    pub fn get_path_genome(&self) -> Vec<(String, Vec<&Path<T, S, U>>)> {
+        let mut result = Vec::new();
+        for x in self.genomes.iter() {
+            let mut aa = Vec::new();
+            for y in x.haplotypes.iter() {
+                let kk: Vec<_> = y.paths.to_vec();
+                aa.extend(kk);
+            }
+            result.push((x.name.clone(), aa));
+        }
+
+        result
+    }
+
+    /// Get all path
+    #[allow(clippy::type_complexity)]
+    pub fn get_paths_direct(&self) -> Vec<(String, Vec<&Path<T, S, U>>)> {
+        let mut result = Vec::new();
+        for x in self.genomes.iter() {
+            for y in x.haplotypes.iter() {
+                y.paths
+                    .iter()
+                    .for_each(|i| result.push((i.name.to_string(), vec![*i])))
+            }
+        }
+        result
+    }
+
+    pub fn number_of_pansn(&self) {
+        println!("Number of genomes: {}", self.get_path_genome().len());
+        println!(
+            "Number of individual haplotypes: {}",
+            self.get_haplo_path().len()
+        );
+        println!("Total number of paths: {}", self.get_paths_direct().len());
+    }
+}

--- a/src/imports/gfa.rs
+++ b/src/imports/gfa.rs
@@ -1,8 +1,8 @@
-use gfa_reader::Gfa;
 use rusqlite::Connection;
 use std::collections::{HashMap, HashSet};
 use std::path::Path as FilePath;
 
+use crate::gfa_reader::Gfa;
 use crate::models::{
     block_group::BlockGroup,
     block_group_edge::BlockGroupEdge,
@@ -25,9 +25,9 @@ fn bool_to_strand(direction: bool) -> Strand {
 pub fn import_gfa(gfa_path: &FilePath, collection_name: &str, conn: &Connection) {
     Collection::create(conn, collection_name);
     let block_group = BlockGroup::create(conn, collection_name, None, "");
-    let gfa: Gfa<u64, (), ()> = Gfa::parse_gfa_file(gfa_path.to_str().unwrap());
-    let mut sequences_by_segment_id: HashMap<u64, Sequence> = HashMap::new();
-    let mut node_ids_by_segment_id: HashMap<u64, i64> = HashMap::new();
+    let gfa: Gfa<String, (), ()> = Gfa::parse_gfa_file(gfa_path.to_str().unwrap());
+    let mut sequences_by_segment_id: HashMap<String, Sequence> = HashMap::new();
+    let mut node_ids_by_segment_id: HashMap<String, i64> = HashMap::new();
 
     for segment in &gfa.segments {
         let input_sequence = segment.sequence.get_string(&gfa.sequence);
@@ -35,9 +35,9 @@ pub fn import_gfa(gfa_path: &FilePath, collection_name: &str, conn: &Connection)
             .sequence_type("DNA")
             .sequence(input_sequence)
             .save(conn);
-        sequences_by_segment_id.insert(segment.id, sequence.clone());
+        sequences_by_segment_id.insert(segment.id.clone(), sequence.clone());
         let node_id = Node::create(conn, &sequence.hash);
-        node_ids_by_segment_id.insert(segment.id, node_id);
+        node_ids_by_segment_id.insert(segment.id.clone(), node_id);
     }
 
     let mut edges = HashSet::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ use std::str;
 
 pub mod config;
 pub mod exports;
+pub mod gfa_reader;
 pub mod graph;
 pub mod imports;
 pub mod migrations;

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,6 +120,9 @@ enum Commands {
         /// The name of the GFA file to export to
         #[arg(short, long)]
         gfa: String,
+        /// An optional sample name
+        #[arg(short, long)]
+        sample: Option<String>,
     },
     Defaults {
         /// The default database to use
@@ -343,13 +346,13 @@ fn main() {
         Some(Commands::Reset { id }) => {
             operation_management::reset(&conn, &operation_conn, &db_uuid, *id);
         }
-        Some(Commands::Export { name, gfa }) => {
+        Some(Commands::Export { name, gfa, sample }) => {
             let name = &name.clone().unwrap_or_else(|| {
                 get_default_collection(&operation_conn)
                     .expect("No collection specified and default not setup.")
             });
             conn.execute("BEGIN TRANSACTION", []).unwrap();
-            export_gfa(&conn, name, &PathBuf::from(gfa));
+            export_gfa(&conn, name, &PathBuf::from(gfa), sample.clone());
             conn.execute("END TRANSACTION", []).unwrap();
         }
         None => {}


### PR DESCRIPTION
There's about 4 things happening here:
1. Changing segment ID to be <node ID>.<sequence start coordinate>
2. Copy/pasting in the GFA reader code from the third party crate (MIT license) so I can fix a bug with parsing a string segment ID
3. Adding a --sample flag to GFA export to limit to just one sample
4. Replacing some manual code for filtering out start/end nodes with a dedicated method