### PR TITLE
Operation hashes

### DIFF
--- a/migrations/operations/01-initial/up.sql
+++ b/migrations/operations/01-initial/up.sql
@@ -15,7 +15,7 @@ CREATE TABLE operation_state (
 CREATE TABLE operation (
   id INTEGER PRIMARY KEY NOT NULL,
   db_uuid TEXT NOT NULL,
-  hash TEXT,
+  hash TEXT NOT NULL,
   parent_id INTEGER,
   branch_id INTEGER NOT NULL,
   collection_name TEXT,
@@ -24,7 +24,7 @@ CREATE TABLE operation (
   FOREIGN KEY(parent_id) REFERENCES operation(id)
   FOREIGN KEY(branch_id) REFERENCES branch(id)
 ) STRICT;
-CREATE UNIQUE INDEX operation_uidx ON operation(db_uuid, hash);
+CREATE UNIQUE INDEX operation_uidx ON operation(db_uuid, branch_id, hash);
 
 CREATE TABLE file_addition (
   id INTEGER PRIMARY KEY NOT NULL,

--- a/migrations/operations/01-initial/up.sql
+++ b/migrations/operations/01-initial/up.sql
@@ -15,6 +15,7 @@ CREATE TABLE operation_state (
 CREATE TABLE operation (
   id INTEGER PRIMARY KEY NOT NULL,
   db_uuid TEXT NOT NULL,
+  hash TEXT,
   parent_id INTEGER,
   branch_id INTEGER NOT NULL,
   collection_name TEXT,
@@ -23,6 +24,7 @@ CREATE TABLE operation (
   FOREIGN KEY(parent_id) REFERENCES operation(id)
   FOREIGN KEY(branch_id) REFERENCES branch(id)
 ) STRICT;
+CREATE UNIQUE INDEX operation_uidx ON operation(db_uuid, hash);
 
 CREATE TABLE file_addition (
   id INTEGER PRIMARY KEY NOT NULL,

--- a/src/main.rs
+++ b/src/main.rs
@@ -490,13 +490,14 @@ fn main() {
                     &db_uuid,
                     current_branch,
                     other_branch.id,
+                    None,
                 );
             } else {
                 println!("No options selected.");
             }
         }
         Some(Commands::Apply { id }) => {
-            operation_management::apply(&conn, &operation_conn, &db_uuid, *id);
+            operation_management::apply(&conn, &operation_conn, *id, None);
         }
         Some(Commands::Checkout { branch, id }) => {
             operation_management::checkout(&conn, &operation_conn, &db_uuid, branch, *id);

--- a/src/models/operations.rs
+++ b/src/models/operations.rs
@@ -5,7 +5,7 @@ use petgraph::graphmap::{DiGraphMap, UnGraphMap};
 use petgraph::visit::{Dfs, Reversed};
 use petgraph::Direction;
 use rusqlite::types::Value;
-use rusqlite::{params, params_from_iter, Connection, Result as SQLResult, Row};
+use rusqlite::{params_from_iter, Connection, Result as SQLResult, Row};
 use std::collections::HashSet;
 use std::string::ToString;
 
@@ -169,14 +169,6 @@ impl Operation {
             "select * from operation where id = ?1",
             vec![Value::from(op_id)],
         )
-    }
-
-    pub fn set_hash(conn: &Connection, op_id: i64, hash: &str) {
-        let mut stmt = conn
-            .prepare("update operation set hash=?2 where id = ?1 and hash is null;")
-            .unwrap();
-        stmt.execute(params!(Value::from(op_id), Value::from(hash.to_string())))
-            .unwrap();
     }
 }
 

--- a/src/models/operations.rs
+++ b/src/models/operations.rs
@@ -5,8 +5,7 @@ use petgraph::graphmap::{DiGraphMap, UnGraphMap};
 use petgraph::visit::{Dfs, Reversed};
 use petgraph::Direction;
 use rusqlite::types::Value;
-use rusqlite::{params, params_from_iter, Connection, Row};
-use sha2::digest::typenum::op;
+use rusqlite::{params, params_from_iter, Connection, Result as SQLResult, Row};
 use std::collections::HashSet;
 use std::string::ToString;
 
@@ -14,7 +13,7 @@ use std::string::ToString;
 pub struct Operation {
     pub id: i64,
     pub db_uuid: String,
-    pub hash: Option<String>,
+    pub hash: String,
     pub parent_id: Option<i64>,
     pub branch_id: i64,
     pub collection_name: Option<String>,
@@ -23,14 +22,15 @@ pub struct Operation {
 }
 
 impl Operation {
-    pub fn create(
+    pub fn create<'a>(
         conn: &Connection,
         db_uuid: &str,
-        collection_name: impl Into<Option<String>>,
+        collection_name: impl Into<Option<&'a str>>,
         change_type: &str,
         change_id: i64,
-    ) -> Operation {
-        let collection_name = collection_name.into();
+        hash: &str,
+    ) -> SQLResult<Operation> {
+        let collection_name = collection_name.into().map(|name| name.to_string());
         let current_op = OperationState::get_operation(conn, db_uuid);
         let current_branch_id =
             OperationState::get_current_branch(conn, db_uuid).expect("No branch is checked out.");
@@ -52,12 +52,13 @@ impl Operation {
             }
         }
 
-        let query = "INSERT INTO operation (db_uuid, collection_name, change_type, change_id, parent_id, branch_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6) RETURNING (id)";
+        let query = "INSERT INTO operation (db_uuid, hash, collection_name, change_type, change_id, parent_id, branch_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7) RETURNING (id)";
         let mut stmt = conn.prepare(query).unwrap();
         let mut rows = stmt
             .query_map(
                 params_from_iter(vec![
                     Value::from(db_uuid.to_string()),
+                    Value::from(hash.to_string()),
                     Value::from(collection_name.clone()),
                     Value::from(change_type.to_string()),
                     Value::from(change_id),
@@ -68,7 +69,7 @@ impl Operation {
                     Ok(Operation {
                         id: row.get(0)?,
                         db_uuid: db_uuid.to_string(),
-                        hash: None,
+                        hash: hash.to_string(),
                         parent_id: current_op,
                         branch_id: current_branch_id,
                         collection_name: collection_name.clone(),
@@ -82,7 +83,7 @@ impl Operation {
         // TODO: error condition here where we can write to disk but transaction fails
         OperationState::set_operation(conn, &operation.db_uuid, operation.id);
         Branch::set_start_operation(conn, current_branch_id, operation.id);
-        operation
+        Ok(operation)
     }
 
     pub fn get_upstream(conn: &Connection, operation_id: i64) -> Vec<i64> {
@@ -570,13 +571,15 @@ mod tests {
         setup_db(op_conn, db_uuid);
 
         let change = FileAddition::create(op_conn, "foo", FileTypes::Fasta);
-        Operation::create(
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
+            "op-1-hash",
+        )
+        .unwrap();
         // operations will be made in ascending order.
         // The branch topology is as follows. () indicate where a branch starts
         //
@@ -600,104 +603,128 @@ mod tests {
         let branch_1 = Branch::create(op_conn, db_uuid, "branch-1");
         let branch_2 = Branch::create(op_conn, db_uuid, "branch-2");
         OperationState::set_branch(op_conn, db_uuid, "branch-1");
-        Operation::create(
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
-        Operation::create(
+            "op-2-hash",
+        )
+        .unwrap();
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
+            "op-3-hash",
+        )
+        .unwrap();
         let branch_1_sub_1 = Branch::create(op_conn, db_uuid, "branch-1-sub-1");
         OperationState::set_branch(op_conn, db_uuid, "branch-1-sub-1");
-        Operation::create(
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
-        Operation::create(
+            "op-4-hash",
+        )
+        .unwrap();
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
+            "op-5-hash",
+        )
+        .unwrap();
 
         // TODO: We should merge the set branch/operation stuff, now that operations track branches we likely don't need set_branch
         OperationState::set_branch(op_conn, db_uuid, "branch-2");
         OperationState::set_operation(op_conn, db_uuid, 1);
-        Operation::create(
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
+            "op-6-hash",
+        )
+        .unwrap();
         let branch_2_midpoint = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
-        Operation::create(
+            "op-7-hash",
+        )
+        .unwrap();
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
+            "op-8-hash",
+        )
+        .unwrap();
 
         let branch_2_sub_1 = Branch::create(op_conn, db_uuid, "branch-2-sub-1");
         OperationState::set_branch(op_conn, db_uuid, "branch-2-sub-1");
-        Operation::create(
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
-        Operation::create(
+            "op-9-hash",
+        )
+        .unwrap();
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
-        Operation::create(
+            "op-10-hash",
+        )
+        .unwrap();
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
+            "op-11-hash",
+        )
+        .unwrap();
 
         OperationState::set_operation(op_conn, db_uuid, branch_2_midpoint.id);
         OperationState::set_branch(op_conn, db_uuid, &branch_2.name);
         let branch_2_midpoint_1 = Branch::create(op_conn, db_uuid, "branch-2-midpoint-1");
         OperationState::set_branch(op_conn, db_uuid, &branch_2_midpoint_1.name);
-        Operation::create(
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
-        Operation::create(
+            "op-12-hash",
+        )
+        .unwrap();
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
+            "op-13-hash",
+        )
+        .unwrap();
 
         let ops = Branch::get_operations(op_conn, branch_2_midpoint_1.id)
             .iter()
@@ -756,63 +783,77 @@ mod tests {
         expected_graph.add_edge(4, 6, ());
         expected_graph.add_edge(1, 7, ());
 
-        Operation::create(
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
-        Operation::create(
+            "op-1-hash",
+        )
+        .unwrap();
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
-        Operation::create(
+            "op-2-hash",
+        )
+        .unwrap();
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
+            "op-3-hash",
+        )
+        .unwrap();
         Branch::create(op_conn, db_uuid, "branch-1");
         OperationState::set_branch(op_conn, db_uuid, "branch-1");
-        Operation::create(
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
-        Operation::create(
+            "op-4-hash",
+        )
+        .unwrap();
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
+            "op-5-hash",
+        )
+        .unwrap();
         OperationState::set_operation(op_conn, db_uuid, 4);
         Branch::create(op_conn, db_uuid, "branch-2");
         OperationState::set_branch(op_conn, db_uuid, "branch-2");
-        Operation::create(
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
+            "op-6-hash",
+        )
+        .unwrap();
         OperationState::set_operation(op_conn, db_uuid, 1);
         Branch::create(op_conn, db_uuid, "branch-3");
         OperationState::set_branch(op_conn, db_uuid, "branch-3");
-        Operation::create(
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
+            "op-7-hash",
+        )
+        .unwrap();
         let graph = Operation::get_operation_graph(op_conn);
 
         assert_eq!(
@@ -849,63 +890,77 @@ mod tests {
         //    branch-1             \-> 4 -> 5
         //    branch-2                  \-> 6
 
-        Operation::create(
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
-        Operation::create(
+            "op-1-hash",
+        )
+        .unwrap();
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
-        Operation::create(
+            "op-2-hash",
+        )
+        .unwrap();
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
+            "op-3-hash",
+        )
+        .unwrap();
         Branch::create(op_conn, db_uuid, "branch-1");
         OperationState::set_branch(op_conn, db_uuid, "branch-1");
-        Operation::create(
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
-        Operation::create(
+            "op-4-hash",
+        )
+        .unwrap();
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
+            "op-5-hash",
+        )
+        .unwrap();
         OperationState::set_operation(op_conn, db_uuid, 4);
         Branch::create(op_conn, db_uuid, "branch-2");
         OperationState::set_branch(op_conn, db_uuid, "branch-2");
-        Operation::create(
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
+            "op-6-hash",
+        )
+        .unwrap();
         OperationState::set_operation(op_conn, db_uuid, 1);
         Branch::create(op_conn, db_uuid, "branch-3");
         OperationState::set_branch(op_conn, db_uuid, "branch-3");
-        Operation::create(
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
+            "op-7-hash",
+        )
+        .unwrap();
 
         assert_eq!(
             Operation::get_path_between(op_conn, 1, 6),
@@ -946,50 +1001,62 @@ mod tests {
         setup_db(op_conn, db_uuid);
 
         let change = FileAddition::create(op_conn, "foo", FileTypes::Fasta);
-        Operation::create(
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
+            "op-1-hash",
+        )
+        .unwrap();
 
-        Operation::create(
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
-        Operation::create(
+            "op-2-hash",
+        )
+        .unwrap();
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
-        Operation::create(
+            "op-3-hash",
+        )
+        .unwrap();
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
-        Operation::create(
+            "op-4-hash",
+        )
+        .unwrap();
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
+            "op-5-hash",
+        )
+        .unwrap();
         OperationState::set_operation(op_conn, db_uuid, 2);
-        Operation::create(
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
+            "op-6-hash",
+        )
+        .unwrap();
     }
 
     #[test]
@@ -1003,52 +1070,64 @@ mod tests {
         setup_db(op_conn, db_uuid);
 
         let change = FileAddition::create(op_conn, "foo", FileTypes::Fasta);
-        Operation::create(
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
+            "op-1-hash",
+        )
+        .unwrap();
 
-        Operation::create(
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
-        Operation::create(
+            "op-2-hash",
+        )
+        .unwrap();
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
-        Operation::create(
+            "op-3-hash",
+        )
+        .unwrap();
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
-        Operation::create(
+            "op-4-hash",
+        )
+        .unwrap();
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
+            "op-5-hash",
+        )
+        .unwrap();
         OperationState::set_operation(op_conn, db_uuid, 2);
         Branch::create(op_conn, db_uuid, "branch-1");
         OperationState::set_branch(op_conn, db_uuid, "branch-1");
-        Operation::create(
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
+            "op-6-hash",
+        )
+        .unwrap();
     }
 
     #[test]
@@ -1064,31 +1143,30 @@ mod tests {
 
         let mut fasta_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         fasta_path.push("fixtures/simple.fa");
-        let collection = "test".to_string();
         import_fasta(
             &fasta_path.to_str().unwrap().to_string(),
-            &collection,
+            "test-1",
             false,
             conn,
             op_conn,
         );
         import_fasta(
             &fasta_path.to_str().unwrap().to_string(),
-            &collection,
+            "test-2",
             false,
             conn,
             op_conn,
         );
         import_fasta(
             &fasta_path.to_str().unwrap().to_string(),
-            &collection,
+            "test-3",
             false,
             conn,
             op_conn,
         );
         import_fasta(
             &fasta_path.to_str().unwrap().to_string(),
-            &collection,
+            "test-4",
             false,
             conn,
             op_conn,
@@ -1097,7 +1175,7 @@ mod tests {
         operation_management::reset(conn, op_conn, db_uuid, 2);
         import_fasta(
             &fasta_path.to_str().unwrap().to_string(),
-            &collection,
+            "test-5",
             false,
             conn,
             op_conn,
@@ -1128,23 +1206,27 @@ mod tests {
         let db2_main = Branch::get_by_name(op_conn, db_uuid2, "main").unwrap().id;
 
         let change = FileAddition::create(op_conn, "foo", FileTypes::Fasta);
-        Operation::create(
+        let _ = Operation::create(
             op_conn,
             db_uuid,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
+            "op-1-hash",
+        )
+        .unwrap();
 
         assert_eq!(Branch::get_operations(op_conn, db2_main), vec![]);
 
-        Operation::create(
+        let _ = Operation::create(
             op_conn,
             db_uuid2,
-            "foo".to_string(),
+            "foo",
             "vcf_addition",
             change.id,
-        );
+            "op-2-hash",
+        )
+        .unwrap();
 
         assert_eq!(
             Branch::get_operations(op_conn, db1_main)

--- a/src/operation_management.rs
+++ b/src/operation_management.rs
@@ -1,4 +1,3 @@
-use crate::calculate_hash;
 use crate::config::get_changeset_path;
 use crate::models::accession::{Accession, AccessionEdge, AccessionEdgeData, AccessionPath};
 use crate::models::block_group::BlockGroup;
@@ -26,7 +25,6 @@ use rusqlite::{session, Connection};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
-use std::fs::File;
 use std::io::{Read, Write};
 use std::{fs, path::PathBuf, str};
 /* General information
@@ -256,7 +254,7 @@ pub fn get_changeset_dependencies(conn: &Connection, mut changes: &[u8]) -> Vec<
     serde_json::to_vec(&s).unwrap()
 }
 
-pub fn write_changeset(conn: &Connection, operation: &Operation, changes: &[u8]) {
+pub fn write_changeset(operation: &Operation, changes: &[u8], dependencies: &[u8]) {
     let change_path =
         get_changeset_path(operation).join(format!("{op_id}.cs", op_id = operation.id));
     let dependency_path =
@@ -264,9 +262,7 @@ pub fn write_changeset(conn: &Connection, operation: &Operation, changes: &[u8])
 
     let mut dependency_file = fs::File::create_new(&dependency_path)
         .unwrap_or_else(|_| panic!("Unable to open {dependency_path:?}"));
-    dependency_file
-        .write_all(&get_changeset_dependencies(conn, changes))
-        .unwrap();
+    dependency_file.write_all(dependencies).unwrap();
 
     let mut file = fs::File::create_new(&change_path)
         .unwrap_or_else(|_| panic!("Unable to open {change_path:?}"));
@@ -752,36 +748,38 @@ pub fn reset(conn: &Connection, operation_conn: &Connection, db_uuid: &str, op_i
     OperationState::set_operation(operation_conn, db_uuid, op_id);
 }
 
-pub fn apply(conn: &Connection, operation_conn: &Connection, db_uuid: &str, op_id: i64) {
-    let mut session = session::Session::new(conn).unwrap();
-    attach_session(&mut session);
-    let change = FileAddition::create(operation_conn, &format!("{op_id}.cs"), FileTypes::Changeset);
-    apply_changeset(conn, &Operation::get_by_id(operation_conn, op_id));
-    let operation = Operation::create(
+pub fn apply<'a>(
+    conn: &Connection,
+    operation_conn: &Connection,
+    op_id: i64,
+    force_hash: impl Into<Option<&'a str>>,
+) {
+    let mut session = start_operation(conn);
+    let operation = Operation::get_by_id(operation_conn, op_id);
+    apply_changeset(conn, &operation);
+    end_operation(
+        conn,
         operation_conn,
-        db_uuid,
+        &mut session,
         None,
+        &format!("{op_id}.cs"),
+        FileTypes::Changeset,
         "changeset_application",
-        change.id,
-    );
-
-    OperationSummary::create(
-        operation_conn,
-        operation.id,
         &format!("Applied changeset {op_id}."),
-    );
-    let mut output = Vec::new();
-    session.changeset_strm(&mut output).unwrap();
-    write_changeset(conn, &operation, &output);
+        force_hash,
+    )
+    .unwrap();
 }
 
-pub fn merge(
+pub fn merge<'a>(
     conn: &Connection,
     operation_conn: &Connection,
     db_uuid: &str,
     source_branch: i64,
     other_branch: i64,
+    force_hash: impl Into<Option<&'a str>>,
 ) {
+    let hash_prefix = force_hash.into();
     let current_branch =
         OperationState::get_current_branch(operation_conn, db_uuid).expect("No current branch.");
     if source_branch != current_branch {
@@ -794,9 +792,18 @@ pub fn merge(
         .position(|op| !current_operations.contains(op))
         .expect("No common operations between two branches.");
     if first_different_op < other_operations.len() {
-        for operation in other_operations[first_different_op..].iter() {
+        for (index, operation) in other_operations[first_different_op..].iter().enumerate() {
             println!("Applying operation {op_id}", op_id = operation.id);
-            apply(conn, operation_conn, db_uuid, operation.id);
+            if let Some(hash) = hash_prefix {
+                apply(
+                    conn,
+                    operation_conn,
+                    operation.id,
+                    format!("{hash}-{index}").as_str(),
+                );
+            } else {
+                apply(conn, operation_conn, operation.id, None);
+            }
         }
     }
 }
@@ -828,52 +835,67 @@ pub fn move_to(conn: &Connection, operation_conn: &Connection, operation: &Opera
     }
 }
 
-pub fn start_operation<'a>(
-    conn: &'a Connection,
-    operation_conn: &'a Connection,
-    file_path: &'a str,
-    file_type: FileTypes,
-    operation_description: &'a str,
-    name: &'a str,
-) -> (session::Session<'a>, Operation) {
+pub fn start_operation(conn: &Connection) -> session::Session {
     let mut session = session::Session::new(conn).unwrap();
     attach_session(&mut session);
-    let change = FileAddition::create(operation_conn, file_path, file_type);
-    let db_uuid = metadata::get_db_uuid(conn);
-    let operation = Operation::create(
-        operation_conn,
-        &db_uuid,
-        name.to_string(),
-        operation_description,
-        change.id,
-    );
-    (session, operation)
+    session
 }
 
-pub fn end_operation(
+#[allow(clippy::too_many_arguments)]
+pub fn end_operation<'a>(
     conn: &Connection,
     operation_conn: &Connection,
-    operation: &Operation,
     session: &mut session::Session,
+    collection_name: impl Into<Option<&'a str>>,
+    file_path: &str,
+    file_type: FileTypes,
+    operation_description: &'a str,
     summary_str: &str,
-) {
-    OperationSummary::create(operation_conn, operation.id, summary_str);
+    force_hash: impl Into<Option<&'a str>>,
+) -> Result<Operation, &'static str> {
+    let collection_name = collection_name.into();
+    let db_uuid = metadata::get_db_uuid(conn);
+    // determine if this operation has already happened
     let mut output = Vec::new();
     session.changeset_strm(&mut output).unwrap();
-    write_changeset(conn, operation, &output);
 
-    let mut hasher = Sha256::new();
-    hasher.update(&output[..]);
-    let mut dependency_models = File::open(
-        get_changeset_path(operation).join(format!("{op_id}.dep", op_id = operation.id)),
-    )
-    .unwrap();
-    let mut output = Vec::new();
-    let _ = dependency_models.read_to_end(&mut output).unwrap();
-    hasher.update(&output[..]);
-    let result = hasher.finalize();
+    let dependencies = get_changeset_dependencies(conn, &output);
 
-    Operation::set_hash(operation_conn, operation.id, &format!("{:x}", result));
+    let hash = if let Some(hash) = force_hash.into() {
+        hash.to_string()
+    } else {
+        let mut hasher = Sha256::new();
+        hasher.update(&output[..]);
+        hasher.update(&dependencies[..]);
+        format!("{:x}", hasher.finalize())
+    };
+
+    operation_conn
+        .execute("SAVEPOINT new_operation;", [])
+        .unwrap();
+
+    let change = FileAddition::create(operation_conn, file_path, file_type);
+
+    match Operation::create(
+        operation_conn,
+        &db_uuid,
+        collection_name,
+        operation_description,
+        change.id,
+        &hash,
+    ) {
+        Ok(operation) => {
+            OperationSummary::create(operation_conn, operation.id, summary_str);
+            write_changeset(&operation, &output, &dependencies);
+            Ok(operation)
+        }
+        Err(_) => {
+            operation_conn
+                .execute("ROLLBACK TRANSACTION TO SAVEPOINT new_operation;", [])
+                .unwrap();
+            Err("Operation already exists.")
+        }
+    }
 }
 
 pub fn attach_session(session: &mut session::Session) {
@@ -936,22 +958,30 @@ mod tests {
         get_connection, get_operation_connection, setup_block_group, setup_gen_dir,
     };
     use crate::updates::vcf::update_with_vcf;
-    use rusqlite::{session::Session, types::Value};
+    use rusqlite::types::Value;
     use std::path::{Path, PathBuf};
 
-    fn create_operation(
+    fn create_operation<'a>(
         conn: &Connection,
         op_conn: &Connection,
         file_path: &str,
         file_type: FileTypes,
         description: &str,
-        name: &str,
+        hash: impl Into<Option<&'a str>>,
     ) -> Operation {
-        let (mut session, op) =
-            start_operation(conn, op_conn, file_path, file_type, description, name);
-        Operation::set_hash(op_conn, op.id, &format!("hash-{id}", id = op.id));
-        end_operation(conn, op_conn, &op, &mut session, "test operation");
-        op
+        let mut session = start_operation(conn);
+        end_operation(
+            conn,
+            op_conn,
+            &mut session,
+            None,
+            file_path,
+            file_type,
+            description,
+            "test operation",
+            hash.into(),
+        )
+        .unwrap()
     }
 
     #[cfg(test)]
@@ -972,16 +1002,16 @@ mod tests {
                 op_conn,
                 "foo",
                 FileTypes::Fasta,
-                "blah",
                 "fasta_addition",
+                "op-1",
             );
             let op_2 = create_operation(
                 conn,
                 op_conn,
                 "foo",
                 FileTypes::Fasta,
-                "blah",
                 "fasta_addition",
+                "op-2",
             );
 
             let branch_1 = Branch::create(op_conn, db_uuid, "branch-1");
@@ -992,16 +1022,16 @@ mod tests {
                 op_conn,
                 "foo",
                 FileTypes::Fasta,
-                "blah",
                 "vcf_addition",
+                "op-3",
             );
             let op_4 = create_operation(
                 conn,
                 op_conn,
                 "foo",
                 FileTypes::Fasta,
-                "blah",
                 "vcf_addition",
+                "op-4",
             );
             checkout(conn, op_conn, db_uuid, &Some("branch-2".to_string()), None);
             let op_5 = create_operation(
@@ -1009,20 +1039,27 @@ mod tests {
                 op_conn,
                 "foo",
                 FileTypes::Fasta,
-                "blah",
                 "vcf_addition",
+                "op-5",
             );
             let op_6 = create_operation(
                 conn,
                 op_conn,
                 "foo",
                 FileTypes::Fasta,
-                "blah",
                 "vcf_addition",
+                "op-6",
             );
 
             checkout(conn, op_conn, db_uuid, &Some("branch-1".to_string()), None);
-            merge(conn, op_conn, db_uuid, branch_1.id, branch_2.id);
+            merge(
+                conn,
+                op_conn,
+                db_uuid,
+                branch_1.id,
+                branch_2.id,
+                "merge-test",
+            );
 
             let b1_ops = Branch::get_operations(op_conn, branch_1.id)
                 .iter()
@@ -1049,7 +1086,8 @@ mod tests {
         let op_conn = &get_operation_connection(None);
         setup_db(op_conn, &db_uuid);
         let change = FileAddition::create(op_conn, "test", FileTypes::Fasta);
-        let operation = Operation::create(op_conn, &db_uuid, "test".to_string(), "test", change.id);
+        let operation =
+            Operation::create(op_conn, &db_uuid, "test", "test", change.id, "some-hash").unwrap();
         OperationState::set_operation(op_conn, &db_uuid, operation.id);
         assert_eq!(OperationState::get_operation(op_conn, &db_uuid).unwrap(), 1);
     }
@@ -1077,8 +1115,7 @@ mod tests {
             .save(conn);
         let existing_node_id = Node::create(conn, existing_seq.hash.as_str(), None);
 
-        let mut session = Session::new(conn).unwrap();
-        attach_session(&mut session);
+        let mut session = start_operation(conn);
 
         let random_seq = Sequence::new()
             .sequence_type("DNA")
@@ -1098,11 +1135,18 @@ mod tests {
             0,
         );
         BlockGroupEdge::bulk_create(conn, bg_id, &[new_edge.id]);
-        let mut output = Vec::new();
-        session.changeset_strm(&mut output).unwrap();
-        let change = FileAddition::create(op_conn, "test", FileTypes::Fasta);
-        let operation = Operation::create(op_conn, &db_uuid, "test".to_string(), "test", change.id);
-        write_changeset(conn, &operation, &output);
+        let operation = end_operation(
+            conn,
+            op_conn,
+            &mut session,
+            "test",
+            "test",
+            FileTypes::Fasta,
+            "test",
+            "test",
+            None,
+        )
+        .unwrap();
 
         let dependency_path =
             get_changeset_path(&operation).join(format!("{op_id}.dep", op_id = operation.id));
@@ -1328,7 +1372,7 @@ mod tests {
         );
 
         // apply changes from branch-1, it will be operation id 2
-        apply(conn, operation_conn, &db_uuid, 2);
+        apply(conn, operation_conn, 2, None);
 
         let foo_bg_id = BlockGroup::get_id(conn, &collection, Some("foo"), "m123");
         let patch_2_seqs = HashSet::from_iter(vec![
@@ -1518,56 +1562,46 @@ mod tests {
     fn test_reset_hides_operations() {
         setup_gen_dir();
         let fasta_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("fixtures/simple.fa");
-        let vcf_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("fixtures/simple.vcf");
         let conn = &mut get_connection(None);
         let db_uuid = metadata::get_db_uuid(conn);
         let operation_conn = &get_operation_connection(None);
         setup_db(operation_conn, &db_uuid);
-        let collection = "test".to_string();
 
         import_fasta(
             &fasta_path.to_str().unwrap().to_string(),
-            &collection,
+            "test-1",
             false,
             conn,
             operation_conn,
         );
 
-        update_with_vcf(
-            &vcf_path.to_str().unwrap().to_string(),
-            &collection,
-            "".to_string(),
-            "".to_string(),
+        import_fasta(
+            &fasta_path.to_str().unwrap().to_string(),
+            "test-2",
+            false,
             conn,
             operation_conn,
-            None,
         );
-        update_with_vcf(
-            &vcf_path.to_str().unwrap().to_string(),
-            &collection,
-            "".to_string(),
-            "".to_string(),
+        import_fasta(
+            &fasta_path.to_str().unwrap().to_string(),
+            "test-3",
+            false,
             conn,
             operation_conn,
-            None,
         );
-        update_with_vcf(
-            &vcf_path.to_str().unwrap().to_string(),
-            &collection,
-            "".to_string(),
-            "".to_string(),
+        import_fasta(
+            &fasta_path.to_str().unwrap().to_string(),
+            "test-4",
+            false,
             conn,
             operation_conn,
-            None,
         );
-        update_with_vcf(
-            &vcf_path.to_str().unwrap().to_string(),
-            &collection,
-            "".to_string(),
-            "".to_string(),
+        import_fasta(
+            &fasta_path.to_str().unwrap().to_string(),
+            "test-5",
+            false,
             conn,
             operation_conn,
-            None,
         );
 
         let branch_id = OperationState::get_current_branch(operation_conn, &db_uuid).unwrap();
@@ -1605,114 +1639,94 @@ mod tests {
         // We want to make sure if we reset branch a to 3 that branch b will still show its operations
         setup_gen_dir();
         let fasta_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("fixtures/simple.fa");
-        let vcf_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("fixtures/simple.vcf");
         let conn = &mut get_connection(None);
         let db_uuid = metadata::get_db_uuid(conn);
         let operation_conn = &get_operation_connection(None);
         setup_db(operation_conn, &db_uuid);
-        let collection = "test".to_string();
 
         let main_branch = Branch::get_by_name(operation_conn, &db_uuid, "main").unwrap();
 
         import_fasta(
             &fasta_path.to_str().unwrap().to_string(),
-            &collection,
+            "test-1",
             false,
             conn,
             operation_conn,
         );
 
-        update_with_vcf(
-            &vcf_path.to_str().unwrap().to_string(),
-            &collection,
-            "".to_string(),
-            "".to_string(),
+        import_fasta(
+            &fasta_path.to_str().unwrap().to_string(),
+            "test-2",
+            false,
             conn,
             operation_conn,
-            None,
         );
 
         let branch_a = Branch::create(operation_conn, &db_uuid, "branch-a");
         OperationState::set_branch(operation_conn, &db_uuid, "branch-a");
-        update_with_vcf(
-            &vcf_path.to_str().unwrap().to_string(),
-            &collection,
-            "".to_string(),
-            "".to_string(),
+        import_fasta(
+            &fasta_path.to_str().unwrap().to_string(),
+            "test-3",
+            false,
             conn,
             operation_conn,
-            None,
         );
-        update_with_vcf(
-            &vcf_path.to_str().unwrap().to_string(),
-            &collection,
-            "".to_string(),
-            "".to_string(),
+        import_fasta(
+            &fasta_path.to_str().unwrap().to_string(),
+            "test-4",
+            false,
             conn,
             operation_conn,
-            None,
         );
-        update_with_vcf(
-            &vcf_path.to_str().unwrap().to_string(),
-            &collection,
-            "".to_string(),
-            "".to_string(),
+        import_fasta(
+            &fasta_path.to_str().unwrap().to_string(),
+            "test-5",
+            false,
             conn,
             operation_conn,
-            None,
         );
         OperationState::set_branch(operation_conn, &db_uuid, "main");
         OperationState::set_operation(operation_conn, &db_uuid, 2);
-        update_with_vcf(
-            &vcf_path.to_str().unwrap().to_string(),
-            &collection,
-            "".to_string(),
-            "".to_string(),
+        import_fasta(
+            &fasta_path.to_str().unwrap().to_string(),
+            "test-6",
+            false,
             conn,
             operation_conn,
-            None,
         );
-        update_with_vcf(
-            &vcf_path.to_str().unwrap().to_string(),
-            &collection,
-            "".to_string(),
-            "".to_string(),
+        import_fasta(
+            &fasta_path.to_str().unwrap().to_string(),
+            "test-7",
+            false,
             conn,
             operation_conn,
-            None,
         );
-        update_with_vcf(
-            &vcf_path.to_str().unwrap().to_string(),
-            &collection,
-            "".to_string(),
-            "".to_string(),
+        import_fasta(
+            &fasta_path.to_str().unwrap().to_string(),
+            "test-8",
+            false,
             conn,
             operation_conn,
-            None,
         );
         OperationState::set_branch(operation_conn, &db_uuid, "branch-a");
         OperationState::set_operation(operation_conn, &db_uuid, 5);
         let branch_b = Branch::create(operation_conn, &db_uuid, "branch-b");
         OperationState::set_branch(operation_conn, &db_uuid, "branch-b");
-        update_with_vcf(
-            &vcf_path.to_str().unwrap().to_string(),
-            &collection,
-            "".to_string(),
-            "".to_string(),
+        import_fasta(
+            &fasta_path.to_str().unwrap().to_string(),
+            "test-9",
+            false,
             conn,
             operation_conn,
-            None,
         );
         OperationState::set_branch(operation_conn, &db_uuid, "branch-a");
         OperationState::set_operation(operation_conn, &db_uuid, 5);
-        update_with_vcf(
-            &vcf_path.to_str().unwrap().to_string(),
-            &collection,
-            "".to_string(),
-            "".to_string(),
+        import_fasta(
+            &fasta_path.to_str().unwrap().to_string(),
+            "test-10",
+            false,
             conn,
             operation_conn,
-            None,
         );
 
         assert_eq!(

--- a/src/operation_management.rs
+++ b/src/operation_management.rs
@@ -887,6 +887,9 @@ pub fn end_operation<'a>(
         Ok(operation) => {
             OperationSummary::create(operation_conn, operation.id, summary_str);
             write_changeset(&operation, &output, &dependencies);
+            operation_conn
+                .execute("RELEASE SAVEPOINT new_operation;", [])
+                .unwrap();
             Ok(operation)
         }
         Err(_) => {

--- a/src/updates/fasta.rs
+++ b/src/updates/fasta.rs
@@ -28,14 +28,7 @@ pub fn update_with_fasta(
     end_coordinate: i64,
     fasta_file_path: &str,
 ) -> io::Result<()> {
-    let (mut session, operation) = operation_management::start_operation(
-        conn,
-        operation_conn,
-        fasta_file_path,
-        FileTypes::Fasta,
-        "fasta_update",
-        collection_name,
-    );
+    let mut session = operation_management::start_operation(conn);
 
     let mut fasta_reader = fasta::io::reader::Builder.build_from_path(fasta_file_path)?;
 
@@ -136,10 +129,15 @@ pub fn update_with_fasta(
     operation_management::end_operation(
         conn,
         operation_conn,
-        &operation,
         &mut session,
+        collection_name,
+        fasta_file_path,
+        FileTypes::Fasta,
+        "fasta_update",
         &summary_str,
-    );
+        None,
+    )
+    .unwrap();
 
     println!("Updated with fasta file: {}", fasta_file_path);
 

--- a/src/updates/gaf.rs
+++ b/src/updates/gaf.rs
@@ -74,15 +74,7 @@ pub fn update_with_gaf<'a, P>(
 {
     // Given a gaf, this will incorporate the alignment into the specified graph, creating new nodes.
 
-    let binding = gaf_path.clone();
-    let (mut session, operation) = operation_management::start_operation(
-        conn,
-        op_conn,
-        binding.as_ref().to_str().unwrap(),
-        FileTypes::GAF,
-        "insert_via_gaf",
-        collection_name,
-    );
+    let mut session = operation_management::start_operation(conn);
 
     let parent_sample = parent_sample.into();
     let sample_name = sample_name
@@ -168,7 +160,7 @@ pub fn update_with_gaf<'a, P>(
 
     let mut gaf_changes: HashMap<String, HashMap<String, (i64, Strand, i64)>> = HashMap::new();
 
-    if let Ok(lines) = read_lines(gaf_path) {
+    if let Ok(lines) = read_lines(&gaf_path) {
         for line in lines.map_while(Result::ok) {
             let entry = re.captures(&line).unwrap();
             let aln_path = &entry["path"];
@@ -365,10 +357,15 @@ pub fn update_with_gaf<'a, P>(
     operation_management::end_operation(
         conn,
         op_conn,
-        &operation,
         &mut session,
+        collection_name,
+        gaf_path.as_ref().to_str().unwrap(),
+        FileTypes::GAF,
+        "insert_via_gaf",
         &format!("{change_count} updates."),
-    );
+        None,
+    )
+    .unwrap();
 }
 
 #[cfg(test)]

--- a/src/updates/library.rs
+++ b/src/updates/library.rs
@@ -30,14 +30,7 @@ pub fn update_with_library(
     parts_file_path: &str,
     library_file_path: &str,
 ) -> std::io::Result<()> {
-    let (mut session, operation) = operation_management::start_operation(
-        conn,
-        operation_conn,
-        library_file_path,
-        FileTypes::CSV,
-        "library_csv_update",
-        collection_name,
-    );
+    let mut session = operation_management::start_operation(conn);
 
     let mut parts_reader = fasta::io::reader::Builder.build_from_path(parts_file_path)?;
 
@@ -197,10 +190,15 @@ pub fn update_with_library(
     operation_management::end_operation(
         conn,
         operation_conn,
-        &operation,
         &mut session,
+        collection_name,
+        library_file_path,
+        FileTypes::CSV,
+        "library_csv_update",
         &summary_str,
-    );
+        None,
+    )
+    .unwrap();
 
     println!("Updated with library file: {}", library_file_path);
 


### PR DESCRIPTION
Adds hashes to make operations unique and usable across databases.

Notable stuff:
* We make operations after a changeset has been made, as I don't want to support operations with null hashes. This requires some fiddling with the start/end operation code but it ended up a bit lighter in the end.
* Sometimes we need to force the hash for easier testing, so that is why you see that.
* Operation is a Result field so we can handle errors on duplicate operations now (not done here though, but is now possible).

Lot of other stuff is just getting old methods changed to work with hashes.