### PR TITLE
Add operation for genbank

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1083,6 +1083,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3504,9 +3505,9 @@ checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
 name = "ruzstd"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c3938e133aac070997ddc684d4b393777d293ba170f2988c8fd5ea2ad4ce21"
+checksum = "fad02996bfc73da3e301efe90b1837be9ed8f4a462b6ed410aa35d00381de89f"
 
 [[package]]
 name = "ryu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ interavl = "0.2.0"
 regex = "1.11.1"
 flate2 = "1.0.35"
 gb-io = "0.7.1"
+thiserror = "1.0.69"
 
 [dev-dependencies]
 cargo-llvm-cov = "0.6.14"

--- a/src/imports/fasta.rs
+++ b/src/imports/fasta.rs
@@ -3,6 +3,7 @@ use std::str;
 
 use crate::calculate_hash;
 use crate::models::file_types::FileTypes;
+use crate::models::operations::OperationInfo;
 use crate::models::{
     block_group::BlockGroup,
     block_group_edge::BlockGroupEdge,
@@ -104,9 +105,11 @@ pub fn import_fasta(
         conn,
         operation_conn,
         &mut session,
-        fasta,
-        FileTypes::Fasta,
-        "fasta_addition",
+        OperationInfo {
+            file_path: fasta.to_string(),
+            file_type: FileTypes::Fasta,
+            description: "fasta_addition".to_string(),
+        },
         &summary_str,
         None,
     )

--- a/src/imports/genbank.rs
+++ b/src/imports/genbank.rs
@@ -230,7 +230,7 @@ mod tests {
     use crate::models::file_types::FileTypes;
     use crate::models::metadata;
     use crate::models::operations::setup_db;
-    use crate::test_helpers::{get_connection, get_operation_connection};
+    use crate::test_helpers::{get_connection, get_operation_connection, setup_gen_dir};
     use std::collections::HashSet;
     use std::fs::File;
     use std::io::BufReader;
@@ -238,6 +238,7 @@ mod tests {
 
     #[test]
     fn test_error_on_invalid_file() {
+        setup_gen_dir();
         let conn = &get_connection(None);
         let db_uuid = metadata::get_db_uuid(conn);
         let op_conn = &get_operation_connection(None);
@@ -263,6 +264,7 @@ mod tests {
 
     #[test]
     fn test_records_operation() {
+        setup_gen_dir();
         let conn = &get_connection(None);
         let db_uuid = metadata::get_db_uuid(conn);
         let op_conn = &get_operation_connection(None);
@@ -290,6 +292,7 @@ mod tests {
         use super::*;
         #[test]
         fn test_parses_insertion() {
+            setup_gen_dir();
             // this file has an insertion from 1426-2220
             let conn = &get_connection(None);
             let db_uuid = metadata::get_db_uuid(conn);
@@ -323,6 +326,7 @@ mod tests {
 
         #[test]
         fn test_parses_deletion() {
+            setup_gen_dir();
             // this file has a deletion from 765-766
             let conn = &get_connection(None);
             let db_uuid = metadata::get_db_uuid(conn);
@@ -374,6 +378,7 @@ mod tests {
 
         #[test]
         fn test_parses_deletion_and_insertion() {
+            setup_gen_dir();
             let conn = &get_connection(None);
             let db_uuid = metadata::get_db_uuid(conn);
             let op_conn = &get_operation_connection(None);
@@ -425,6 +430,7 @@ mod tests {
 
         #[test]
         fn test_parses_substitution() {
+            setup_gen_dir();
             // replacing a sequence ends up with the same result as doing a compound delete + insert
             // in the above test.
             let conn = &get_connection(None);

--- a/src/imports/genbank.rs
+++ b/src/imports/genbank.rs
@@ -213,12 +213,13 @@ where
             Err(e) => return Err(GenBankError::ParseError(format!("Failed to parse {}", e))),
         }
     }
+    let filename = operation_info.file_path.clone();
     end_operation(
         conn,
         op_conn,
         &mut session,
         operation_info,
-        "something",
+        &format!("Genbank Import of {filename}",),
         None,
     )
     .map_err(GenBankError::OperationError)

--- a/src/imports/genbank.rs
+++ b/src/imports/genbank.rs
@@ -33,8 +33,8 @@ pub fn import_genbank<'a, R>(
     op_conn: &Connection,
     data: R,
     collection: impl Into<Option<&'a str>>,
-    operation_info: impl Into<Option<OperationInfo>>,
-) -> Result<Option<Operation>, GenBankError>
+    operation_info: OperationInfo,
+) -> Result<Operation, GenBankError>
 where
     R: Read,
 {
@@ -213,23 +213,21 @@ where
             Err(e) => return Err(GenBankError::ParseError(format!("Failed to parse {}", e))),
         }
     }
-    if let Some(op_info) = operation_info.into() {
-        Ok(Some(end_operation(
-            conn,
-            op_conn,
-            &mut session,
-            op_info,
-            "something",
-            None,
-        )?))
-    } else {
-        Ok(None)
-    }
+    end_operation(
+        conn,
+        op_conn,
+        &mut session,
+        operation_info,
+        "something",
+        None,
+    )
+    .map_err(GenBankError::OperationError)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::file_types::FileTypes;
     use crate::models::metadata;
     use crate::models::operations::setup_db;
     use crate::test_helpers::{get_connection, get_operation_connection};
@@ -250,7 +248,11 @@ mod tests {
                 op_conn,
                 BufReader::new("this is not valid".as_bytes()),
                 None,
-                None
+                OperationInfo {
+                    file_path: "".to_string(),
+                    file_type: FileTypes::GenBank,
+                    description: "test".to_string(),
+                }
             ),
             Err(GenBankError::ParseError(
                 "Failed to parse Syntax error: Error Tag while parsing [this is not valid]"
@@ -272,7 +274,17 @@ mod tests {
             let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
                 .join("fixtures/geneious_genbank/insertion.gb");
             let file = File::open(&path).unwrap();
-            let _ = import_genbank(conn, op_conn, BufReader::new(file), None, None);
+            let _ = import_genbank(
+                conn,
+                op_conn,
+                BufReader::new(file),
+                None,
+                OperationInfo {
+                    file_path: "".to_string(),
+                    file_type: FileTypes::GenBank,
+                    description: "test".to_string(),
+                },
+            );
             let f = reader::parse_file(&path).unwrap();
             let seq = str::from_utf8(&f[0].seq).unwrap().to_string();
             let seqs = BlockGroup::get_all_sequences(conn, 1, false);
@@ -295,7 +307,17 @@ mod tests {
             let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
                 .join("fixtures/geneious_genbank/deletion.gb");
             let file = File::open(&path).unwrap();
-            let _ = import_genbank(conn, op_conn, BufReader::new(file), None, None);
+            let _ = import_genbank(
+                conn,
+                op_conn,
+                BufReader::new(file),
+                None,
+                OperationInfo {
+                    file_path: "".to_string(),
+                    file_type: FileTypes::GenBank,
+                    description: "test".to_string(),
+                },
+            );
             let f = reader::parse_file(&path).unwrap();
             let seq = str::from_utf8(&f[0].seq).unwrap().to_string();
             let deleted: String = normalize_string(
@@ -335,7 +357,17 @@ mod tests {
             let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
                 .join("fixtures/geneious_genbank/deletion_and_insertion.gb");
             let file = File::open(&path).unwrap();
-            let _ = import_genbank(conn, op_conn, BufReader::new(file), None, None);
+            let _ = import_genbank(
+                conn,
+                op_conn,
+                BufReader::new(file),
+                None,
+                OperationInfo {
+                    file_path: "".to_string(),
+                    file_type: FileTypes::GenBank,
+                    description: "test".to_string(),
+                },
+            );
             let f = reader::parse_file(&path).unwrap();
             let seq = str::from_utf8(&f[0].seq).unwrap().to_string();
             let deleted: String = normalize_string(
@@ -378,7 +410,17 @@ mod tests {
             let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
                 .join("fixtures/geneious_genbank/substitution.gb");
             let file = File::open(&path).unwrap();
-            let _ = import_genbank(conn, op_conn, BufReader::new(file), None, None);
+            let _ = import_genbank(
+                conn,
+                op_conn,
+                BufReader::new(file),
+                None,
+                OperationInfo {
+                    file_path: "".to_string(),
+                    file_type: FileTypes::GenBank,
+                    description: "test".to_string(),
+                },
+            );
             let f = reader::parse_file(&path).unwrap();
             let seq = str::from_utf8(&f[0].seq).unwrap().to_string();
             let deleted: String = normalize_string(

--- a/src/imports/genbank.rs
+++ b/src/imports/genbank.rs
@@ -261,6 +261,30 @@ mod tests {
         )
     }
 
+    #[test]
+    fn test_records_operation() {
+        let conn = &get_connection(None);
+        let db_uuid = metadata::get_db_uuid(conn);
+        let op_conn = &get_operation_connection(None);
+        setup_db(op_conn, &db_uuid);
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("fixtures/geneious_genbank/insertion.gb");
+        let file = File::open(&path).unwrap();
+        let operation = import_genbank(
+            conn,
+            op_conn,
+            BufReader::new(file),
+            None,
+            OperationInfo {
+                file_path: path.to_str().unwrap().to_string(),
+                file_type: FileTypes::GenBank,
+                description: "test".to_string(),
+            },
+        )
+        .unwrap();
+        assert_eq!(Operation::get_by_hash(op_conn, &operation.hash), operation);
+    }
+
     #[cfg(test)]
     mod geneious_genbanks {
         use super::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,8 +10,9 @@ use gen::get_connection;
 use gen::imports::fasta::import_fasta;
 use gen::imports::genbank::import_genbank;
 use gen::imports::gfa::import_gfa;
+use gen::models::file_types::FileTypes;
 use gen::models::metadata;
-use gen::models::operations::{setup_db, Branch, Operation, OperationState};
+use gen::models::operations::{setup_db, Branch, Operation, OperationInfo, OperationState};
 use gen::operation_management;
 use gen::operation_management::parse_patch_operations;
 use gen::patch;
@@ -334,7 +335,17 @@ fn main() {
                 import_gfa(&PathBuf::from(gfa.clone().unwrap()), name, None, &conn);
             } else if let Some(gb) = gb {
                 let f = File::open(gb).unwrap();
-                import_genbank(&conn, &f, name.deref());
+                let _ = import_genbank(
+                    &conn,
+                    &operation_conn,
+                    &f,
+                    name.deref(),
+                    OperationInfo {
+                        file_path: gb.clone(),
+                        file_type: FileTypes::GenBank,
+                        description: "GenBank Import".to_string(),
+                    },
+                );
                 println!("Genbank imported.");
             } else {
                 conn.execute("ROLLBACK TRANSACTION;", []).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,14 +7,14 @@ use gen::annotations::gff::propagate_gff;
 use gen::exports::fasta::export_fasta;
 use gen::exports::gfa::export_gfa;
 use gen::get_connection;
-use gen::imports::fasta::import_fasta;
+use gen::imports::fasta::{import_fasta, FastaError};
 use gen::imports::genbank::import_genbank;
 use gen::imports::gfa::import_gfa;
 use gen::models::file_types::FileTypes;
 use gen::models::metadata;
 use gen::models::operations::{setup_db, Branch, Operation, OperationInfo, OperationState};
 use gen::operation_management;
-use gen::operation_management::parse_patch_operations;
+use gen::operation_management::{parse_patch_operations, OperationError};
 use gen::patch;
 use gen::updates::fasta::update_with_fasta;
 use gen::updates::gaf::{transform_csv_to_fasta, update_with_gaf};
@@ -324,7 +324,9 @@ fn main() {
                     &operation_conn,
                 ) {
                     Ok(_) => println!("Fasta imported."),
-                    Err("No changes.") => println!("Fasta contents already exist."),
+                    Err(FastaError::OperationError(OperationError::NoChanges)) => {
+                        println!("Fasta contents already exist.")
+                    }
                     Err(_) => {
                         conn.execute("ROLLBACK TRANSACTION;", []).unwrap();
                         operation_conn.execute("ROLLBACK TRANSACTION;", []).unwrap();

--- a/src/models/file_types.rs
+++ b/src/models/file_types.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Deserialize, Serialize)]
 pub enum FileTypes {
+    GenBank,
     Fasta,
     GFA,
     GAF,
@@ -15,6 +16,7 @@ pub enum FileTypes {
 impl ToSql for FileTypes {
     fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
         let result = match self {
+            FileTypes::GenBank => "gb".into(),
             FileTypes::Fasta => "fasta".into(),
             FileTypes::GFA => "gfa".into(),
             FileTypes::VCF => "vcf".into(),
@@ -29,6 +31,7 @@ impl ToSql for FileTypes {
 impl From<FileTypes> for Value {
     fn from(value: FileTypes) -> Value {
         let result = match value {
+            FileTypes::GenBank => "gb",
             FileTypes::Fasta => "fasta",
             FileTypes::GFA => "gfa",
             FileTypes::VCF => "vcf",
@@ -43,6 +46,7 @@ impl From<FileTypes> for Value {
 impl FromSql for FileTypes {
     fn column_result(value: ValueRef) -> FromSqlResult<Self> {
         let result = match value.as_str() {
+            Ok("gb") => FileTypes::GenBank,
             Ok("fasta") => FileTypes::Fasta,
             Ok("gfa") => FileTypes::GFA,
             Ok("vcf") => FileTypes::VCF,

--- a/src/models/operations.rs
+++ b/src/models/operations.rs
@@ -185,6 +185,12 @@ impl Query for Operation {
     }
 }
 
+pub struct OperationInfo {
+    pub file_path: String,
+    pub file_type: FileTypes,
+    pub description: String,
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 pub struct FileAddition {
     pub id: i64,

--- a/src/operation_management.rs
+++ b/src/operation_management.rs
@@ -8,7 +8,7 @@ use crate::models::file_types::FileTypes;
 use crate::models::metadata;
 use crate::models::node::Node;
 use crate::models::operations::{
-    Branch, FileAddition, Operation, OperationState, OperationSummary,
+    Branch, FileAddition, Operation, OperationInfo, OperationState, OperationSummary,
 };
 use crate::models::path::Path;
 use crate::models::sample::Sample;
@@ -778,9 +778,11 @@ pub fn apply<'a>(
         conn,
         operation_conn,
         &mut session,
-        &format!("{op_hash}.cs"),
-        FileTypes::Changeset,
-        "changeset_application",
+        OperationInfo {
+            file_path: format!("{op_hash}.cs"),
+            file_type: FileTypes::Changeset,
+            description: "changeset_application".to_string(),
+        },
         &format!("Applied changeset {op_hash}."),
         force_hash,
     )
@@ -874,9 +876,7 @@ pub fn end_operation<'a>(
     conn: &Connection,
     operation_conn: &Connection,
     session: &mut session::Session,
-    file_path: &str,
-    file_type: FileTypes,
-    operation_description: &'a str,
+    operation_info: OperationInfo,
     summary_str: &str,
     force_hash: impl Into<Option<&'a str>>,
 ) -> Result<Operation, &'static str> {
@@ -903,12 +903,16 @@ pub fn end_operation<'a>(
         .execute("SAVEPOINT new_operation;", [])
         .unwrap();
 
-    let change = FileAddition::create(operation_conn, file_path, file_type);
+    let change = FileAddition::create(
+        operation_conn,
+        &operation_info.file_path,
+        operation_info.file_type,
+    );
 
     match Operation::create(
         operation_conn,
         &db_uuid,
-        operation_description,
+        &operation_info.description,
         change.id,
         &hash,
     ) {
@@ -1418,9 +1422,11 @@ mod tests {
             conn,
             op_conn,
             &mut session,
-            "test",
-            FileTypes::Fasta,
-            "test",
+            OperationInfo {
+                file_path: "test".to_string(),
+                file_type: FileTypes::Fasta,
+                description: "test".to_string(),
+            },
             "test",
             None,
         )

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -4,6 +4,7 @@ use crate::models::traits::Query;
 use crate::operation_management;
 use crate::operation_management::{
     apply_changeset, end_operation, load_changeset, load_changeset_dependencies, start_operation,
+    OperationError,
 };
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
@@ -102,9 +103,10 @@ pub fn apply_patches(conn: &Connection, op_conn: &Connection, patches: &[Operati
                 println!("Successfully applied operation.");
             }
             Err(e) => match e {
-                "Operation already exists." => println!("Operation already applied. Skipping."),
-                "No changes." => println!("No new changes present in operation. Skipping."),
-                _ => panic!("error is {e:?}"),
+                OperationError::OperationExists => println!("Operation already applied. Skipping."),
+                OperationError::NoChanges => {
+                    println!("No new changes present in operation. Skipping.")
+                }
             },
         }
     }

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -1,5 +1,5 @@
 use crate::config::get_changeset_path;
-use crate::models::operations::{FileAddition, Operation, OperationSummary};
+use crate::models::operations::{FileAddition, Operation, OperationInfo, OperationSummary};
 use crate::models::traits::Query;
 use crate::operation_management;
 use crate::operation_management::{
@@ -90,9 +90,11 @@ pub fn apply_patches(conn: &Connection, op_conn: &Connection, patches: &[Operati
             conn,
             op_conn,
             &mut session,
-            &patch.files.file_path,
-            patch.files.file_type,
-            &op_info.change_type,
+            OperationInfo {
+                file_path: patch.files.file_path.clone(),
+                file_type: patch.files.file_type,
+                description: op_info.change_type.clone(),
+            },
             &patch.summary.summary,
             None,
         ) {

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -18,7 +18,7 @@ use crate::models::collection::Collection;
 use crate::models::edge::Edge;
 use crate::models::file_types::FileTypes;
 use crate::models::node::{Node, PATH_END_NODE_ID, PATH_START_NODE_ID};
-use crate::models::operations::Operation;
+use crate::models::operations::{Operation, OperationInfo};
 use crate::models::path::Path;
 use crate::models::sample::Sample;
 use crate::models::sequence::Sequence;
@@ -218,9 +218,11 @@ pub fn create_operation<'a>(
         conn,
         op_conn,
         &mut session,
-        file_path,
-        file_type,
-        description,
+        OperationInfo {
+            file_path: file_path.to_string(),
+            file_type,
+            description: description.to_string(),
+        },
         "test operation",
         hash.into(),
     )

--- a/src/updates/fasta.rs
+++ b/src/updates/fasta.rs
@@ -3,6 +3,7 @@ use rusqlite;
 use rusqlite::{types::Value as SQLValue, Connection};
 use std::{io, str};
 
+use crate::models::operations::OperationInfo;
 use crate::models::{
     block_group::{BlockGroup, PathChange},
     edge::Edge,
@@ -130,9 +131,11 @@ pub fn update_with_fasta(
         conn,
         operation_conn,
         &mut session,
-        fasta_file_path,
-        FileTypes::Fasta,
-        "fasta_update",
+        OperationInfo {
+            file_path: fasta_file_path.to_string(),
+            file_type: FileTypes::Fasta,
+            description: "fasta_update".to_string(),
+        },
         &summary_str,
         None,
     )

--- a/src/updates/gaf.rs
+++ b/src/updates/gaf.rs
@@ -5,6 +5,7 @@ use crate::models::block_group_edge::BlockGroupEdge;
 use crate::models::edge::{Edge, EdgeData};
 use crate::models::file_types::FileTypes;
 use crate::models::node::{Node, PATH_END_NODE_ID, PATH_START_NODE_ID};
+use crate::models::operations::OperationInfo;
 use crate::models::sample::Sample;
 use crate::models::sequence::Sequence;
 use crate::models::strand::Strand;
@@ -358,9 +359,11 @@ pub fn update_with_gaf<'a, P>(
         conn,
         op_conn,
         &mut session,
-        gaf_path.as_ref().to_str().unwrap(),
-        FileTypes::GAF,
-        "insert_via_gaf",
+        OperationInfo {
+            file_path: gaf_path.as_ref().to_str().unwrap().to_string(),
+            file_type: FileTypes::GAF,
+            description: "insert_via_gaf".to_string(),
+        },
         &format!("{change_count} updates."),
         None,
     )

--- a/src/updates/library.rs
+++ b/src/updates/library.rs
@@ -12,6 +12,7 @@ use crate::models::block_group_edge::BlockGroupEdge;
 use crate::models::edge::{Edge, EdgeData};
 use crate::models::file_types::FileTypes;
 use crate::models::node::Node;
+use crate::models::operations::OperationInfo;
 use crate::models::sample::Sample;
 use crate::models::sequence::Sequence;
 use crate::models::strand::Strand;
@@ -191,9 +192,11 @@ pub fn update_with_library(
         conn,
         operation_conn,
         &mut session,
-        library_file_path,
-        FileTypes::CSV,
-        "library_csv_update",
+        OperationInfo {
+            file_path: library_file_path.to_string(),
+            file_type: FileTypes::CSV,
+            description: "library_csv_update".to_string(),
+        },
         &summary_str,
         None,
     )

--- a/src/updates/vcf.rs
+++ b/src/updates/vcf.rs
@@ -463,7 +463,7 @@ pub fn update_with_vcf<'a>(
         }
     }
 
-    Ok(end_operation(
+    end_operation(
         conn,
         operation_conn,
         &mut session,
@@ -474,7 +474,8 @@ pub fn update_with_vcf<'a>(
         },
         &summary_str,
         None,
-    )?)
+    )
+    .map_err(VcfError::OperationError)
 }
 
 #[cfg(test)]

--- a/src/updates/vcf.rs
+++ b/src/updates/vcf.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::{io, str};
 
+use crate::models::operations::OperationInfo;
 use crate::models::{
     block_group::{BlockGroup, BlockGroupData, PathCache, PathChange},
     file_types::FileTypes,
@@ -459,9 +460,11 @@ pub fn update_with_vcf<'a>(
         conn,
         operation_conn,
         &mut session,
-        vcf_path,
-        FileTypes::VCF,
-        "vcf_addition",
+        OperationInfo {
+            file_path: vcf_path.to_string(),
+            file_type: FileTypes::VCF,
+            description: "vcf_addition".to_string(),
+        },
         &summary_str,
         None,
     )


### PR DESCRIPTION
This is why I wanted a separate PR. The signature for import_genbank is a reader -- not a file path so operations couldn't be made. So I added a method to add operation info if it should be tracked. The reason for this is I felt like our import operations are a bit too constrained to create apis around. Accepting a stream of input makes it easier for supporting pipes/etc. and other non-file based inputs. Having the caller responsible for telling the function the file name instead of coupling that to the reader method (being a file-like object) gives a bit more flexibility.

I also wanted better errors here, but it required refactoring a bunch of other error calls.