### PR TITLE
Add sample creation to import

### DIFF
--- a/src/annotations/gff.rs
+++ b/src/annotations/gff.rs
@@ -119,6 +119,7 @@ mod tests {
         import_fasta(
             &fasta_path.to_str().unwrap().to_string(),
             "test",
+            None,
             false,
             &conn,
             op_conn,

--- a/src/exports/fasta.rs
+++ b/src/exports/fasta.rs
@@ -59,6 +59,7 @@ mod tests {
         import_fasta(
             &fasta_path.to_str().unwrap().to_string(),
             &collection,
+            None,
             false,
             conn,
             op_conn,
@@ -108,6 +109,7 @@ mod tests {
         import_fasta(
             &fasta_path.to_str().unwrap().to_string(),
             &collection,
+            None,
             false,
             conn,
             op_conn,

--- a/src/exports/genbank.rs
+++ b/src/exports/genbank.rs
@@ -394,6 +394,7 @@ mod tests {
             op_conn,
             BufReader::new(file),
             None,
+            None,
             OperationInfo {
                 file_path: path.to_str().unwrap().to_string(),
                 file_type: FileTypes::GenBank,
@@ -422,6 +423,7 @@ mod tests {
             op_conn,
             BufReader::new(file),
             None,
+            None,
             OperationInfo {
                 file_path: path.to_str().unwrap().to_string(),
                 file_type: FileTypes::GenBank,
@@ -449,6 +451,7 @@ mod tests {
             conn,
             op_conn,
             BufReader::new(file),
+            None,
             None,
             OperationInfo {
                 file_path: path.to_str().unwrap().to_string(),

--- a/src/imports/fasta.rs
+++ b/src/imports/fasta.rs
@@ -4,6 +4,7 @@ use std::str;
 use crate::calculate_hash;
 use crate::models::file_types::FileTypes;
 use crate::models::operations::OperationInfo;
+use crate::models::sample::Sample;
 use crate::models::{
     block_group::BlockGroup,
     block_group_edge::{BlockGroupEdge, BlockGroupEdgeData},
@@ -30,6 +31,7 @@ pub enum FastaError {
 pub fn import_fasta(
     fasta: &String,
     name: &str,
+    sample: Option<&str>,
     shallow: bool,
     conn: &Connection,
     operation_conn: &Connection,
@@ -45,6 +47,9 @@ pub fn import_fasta(
             name: name.to_string(),
         }
     };
+    if let Some(sample_name) = sample {
+        Sample::get_or_create(conn, sample_name);
+    }
     let mut summary: HashMap<String, i64> = HashMap::new();
 
     for result in reader.records() {
@@ -76,7 +81,7 @@ pub fn import_fasta(
                 hash = seq.hash
             )),
         );
-        let block_group = BlockGroup::create(conn, &collection.name, None, &name);
+        let block_group = BlockGroup::create(conn, &collection.name, sample, &name);
         let edge_into = Edge::create(
             conn,
             PATH_START_NODE_ID,
@@ -159,6 +164,7 @@ mod tests {
         import_fasta(
             &fasta_path.to_str().unwrap().to_string(),
             "test",
+            None,
             false,
             &conn,
             op_conn,
@@ -189,6 +195,7 @@ mod tests {
         import_fasta(
             &fasta_path.to_str().unwrap().to_string(),
             "test",
+            None,
             true,
             &conn,
             op_conn,
@@ -221,6 +228,7 @@ mod tests {
         import_fasta(
             &fasta_path.to_str().unwrap().to_string(),
             &collection,
+            None,
             false,
             conn,
             op_conn,
@@ -234,6 +242,7 @@ mod tests {
             import_fasta(
                 &fasta_path.to_str().unwrap().to_string(),
                 &collection,
+                None,
                 false,
                 conn,
                 op_conn,

--- a/src/imports/genbank.rs
+++ b/src/imports/genbank.rs
@@ -187,7 +187,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::imports::fasta::import_fasta;
     use crate::models::file_types::FileTypes;
     use crate::models::metadata;
     use crate::models::operations::setup_db;

--- a/src/imports/gfa.rs
+++ b/src/imports/gfa.rs
@@ -4,6 +4,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::Path as FilePath;
 
 use crate::gfa_reader::Gfa;
+use crate::models::sample::Sample;
 use crate::models::{
     block_group::BlockGroup,
     block_group_edge::{BlockGroupEdge, BlockGroupEdgeData},
@@ -31,6 +32,9 @@ pub fn import_gfa<'a>(
 ) {
     Collection::create(conn, collection_name);
     let sample_name = sample_name.into();
+    if let Some(sample_name) = sample_name {
+        Sample::get_or_create(conn, sample_name);
+    }
     let block_group = BlockGroup::create(conn, collection_name, sample_name, "");
     let gfa: Gfa<String, (), ()> = Gfa::parse_gfa_file(gfa_path.to_str().unwrap());
     let mut sequences_by_segment_id: HashMap<&String, Sequence> = HashMap::new();

--- a/src/imports/gfa.rs
+++ b/src/imports/gfa.rs
@@ -270,6 +270,20 @@ mod tests {
     }
 
     #[test]
+    fn test_creates_sample() {
+        setup_gen_dir();
+        let mut gfa_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        gfa_path.push("fixtures/simple.gfa");
+        let collection_name = "test".to_string();
+        let conn = &get_connection(None);
+        import_gfa(&gfa_path, &collection_name, "new-sample", conn);
+        assert_eq!(
+            Sample::get_by_name(conn, "new-sample").unwrap().name,
+            "new-sample"
+        );
+    }
+
+    #[test]
     fn test_import_no_path_gfa() {
         let mut gfa_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         gfa_path.push("fixtures/no_path.gfa");

--- a/src/models/sample.rs
+++ b/src/models/sample.rs
@@ -126,4 +126,12 @@ impl Sample {
         let samples = Sample::query(conn, "select * from samples;", rusqlite::params!());
         samples.iter().map(|s| s.name.clone()).collect()
     }
+
+    pub fn get_by_name(conn: &Connection, name: &str) -> SQLResult<Sample> {
+        Sample::get(
+            conn,
+            "select * from samples where name = ?1;",
+            rusqlite::params!(name),
+        )
+    }
 }

--- a/src/operation_management.rs
+++ b/src/operation_management.rs
@@ -1495,6 +1495,7 @@ mod tests {
         import_fasta(
             &fasta_path.to_str().unwrap().to_string(),
             &collection,
+            None,
             false,
             conn,
             operation_conn,
@@ -1649,6 +1650,7 @@ mod tests {
         let _op_1 = import_fasta(
             &fasta_path.to_str().unwrap().to_string(),
             &collection,
+            None,
             false,
             conn,
             operation_conn,
@@ -1789,6 +1791,7 @@ mod tests {
         import_fasta(
             &fasta_path.to_str().unwrap().to_string(),
             &collection,
+            None,
             false,
             conn,
             operation_conn,

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -137,6 +137,7 @@ mod tests {
         let op_1 = import_fasta(
             &fasta_path.to_str().unwrap().to_string(),
             &collection,
+            None,
             false,
             conn,
             operation_conn,
@@ -174,6 +175,7 @@ mod tests {
         let op_1 = import_fasta(
             &fasta_path.to_str().unwrap().to_string(),
             &collection,
+            None,
             false,
             conn,
             operation_conn,
@@ -214,6 +216,7 @@ mod tests {
         let _op_1 = import_fasta(
             &fasta_path.to_str().unwrap().to_string(),
             &collection,
+            None,
             false,
             conn,
             operation_conn,

--- a/src/updates/fasta.rs
+++ b/src/updates/fasta.rs
@@ -178,6 +178,7 @@ mod tests {
         import_fasta(
             &fasta_path.to_str().unwrap().to_string(),
             &collection,
+            None,
             false,
             conn,
             op_conn,
@@ -239,6 +240,7 @@ mod tests {
         let _ = import_fasta(
             &fasta_path.to_str().unwrap().to_string(),
             &collection,
+            None,
             false,
             conn,
             op_conn,
@@ -312,6 +314,7 @@ mod tests {
         import_fasta(
             &fasta_path.to_str().unwrap().to_string(),
             &collection,
+            None,
             false,
             conn,
             op_conn,
@@ -391,6 +394,7 @@ mod tests {
         import_fasta(
             &fasta_path.to_str().unwrap().to_string(),
             &collection,
+            None,
             false,
             conn,
             op_conn,
@@ -464,6 +468,7 @@ mod tests {
         import_fasta(
             &fasta_path.to_str().unwrap().to_string(),
             &collection,
+            None,
             false,
             conn,
             op_conn,
@@ -535,6 +540,7 @@ mod tests {
         import_fasta(
             &fasta_path.to_str().unwrap().to_string(),
             &collection,
+            None,
             false,
             conn,
             op_conn,

--- a/src/updates/genbank.rs
+++ b/src/updates/genbank.rs
@@ -298,6 +298,7 @@ mod tests {
                 op_conn,
                 BufReader::new(file),
                 None,
+                None,
                 OperationInfo {
                     file_path: "".to_string(),
                     file_type: FileTypes::GenBank,
@@ -348,6 +349,7 @@ mod tests {
                 conn,
                 op_conn,
                 BufReader::new(file),
+                None,
                 None,
                 OperationInfo {
                     file_path: "".to_string(),
@@ -409,6 +411,7 @@ mod tests {
                 conn,
                 op_conn,
                 BufReader::new(file),
+                None,
                 None,
                 OperationInfo {
                     file_path: "".to_string(),

--- a/src/updates/library.rs
+++ b/src/updates/library.rs
@@ -232,6 +232,7 @@ mod tests {
         import_fasta(
             &fasta_path.to_str().unwrap().to_string(),
             &collection,
+            None,
             false,
             conn,
             op_conn,

--- a/src/updates/vcf.rs
+++ b/src/updates/vcf.rs
@@ -506,6 +506,7 @@ mod tests {
         import_fasta(
             &fasta_path.to_str().unwrap().to_string(),
             &collection,
+            None,
             false,
             conn,
             op_conn,
@@ -569,6 +570,7 @@ mod tests {
         import_fasta(
             &fasta_path.to_str().unwrap().to_string(),
             &collection,
+            None,
             false,
             conn,
             op_conn,
@@ -621,6 +623,7 @@ mod tests {
         import_fasta(
             &fasta_path.to_str().unwrap().to_string(),
             &collection,
+            None,
             false,
             conn,
             op_conn,
@@ -674,6 +677,7 @@ mod tests {
         import_fasta(
             &fasta_path.to_str().unwrap().to_string(),
             &collection,
+            None,
             false,
             conn,
             op_conn,
@@ -719,6 +723,7 @@ mod tests {
         import_fasta(
             &fasta_path.to_str().unwrap().to_string(),
             &collection,
+            None,
             false,
             conn,
             op_conn,
@@ -770,6 +775,7 @@ mod tests {
         import_fasta(
             &fasta_path.to_str().unwrap().to_string(),
             &collection,
+            None,
             false,
             conn,
             op_conn,
@@ -827,6 +833,7 @@ mod tests {
         import_fasta(
             &fasta_path.to_str().unwrap().to_string(),
             &collection,
+            None,
             false,
             conn,
             op_conn,
@@ -864,6 +871,7 @@ mod tests {
         import_fasta(
             &fasta_path.to_str().unwrap().to_string(),
             &collection,
+            None,
             false,
             conn,
             op_conn,
@@ -919,6 +927,7 @@ mod tests {
         import_fasta(
             &fasta_path.to_str().unwrap().to_string(),
             &collection,
+            None,
             false,
             conn,
             op_conn,
@@ -982,6 +991,7 @@ mod tests {
         import_fasta(
             &fasta_path.to_str().unwrap().to_string(),
             &collection,
+            None,
             false,
             conn,
             op_conn,


### PR DESCRIPTION
So sample names can be declared at import time instead of always having to be null