### PR TITLE
Add db_uuid to operation hash

### DIFF
--- a/src/operation_management.rs
+++ b/src/operation_management.rs
@@ -1007,6 +1007,7 @@ pub fn end_operation<'a>(
             return Err(OperationError::NoChanges);
         }
         let mut hasher = Sha256::new();
+        hasher.update(&db_uuid[..]);
         hasher.update(&output[..]);
         hasher.update(&dependencies[..]);
         format!("{:x}", hasher.finalize())

--- a/src/views/patch.rs
+++ b/src/views/patch.rs
@@ -206,8 +206,16 @@ pub fn view_patches(patches: &[OperationPatch]) -> HashMap<String, HashMap<i64, 
                 // Edges between adjacent blocks from the same node don't have an arrowhead
                 // and are dashed because they represent the reference and can't be traversed.
                 // TODO: In a heterozygous genome this isn't true. Check needs to be expanded.
-                let style = if src == dest && d_fp == s_tp + 1 { "dashed" } else { "solid" };
-                let arrow = if src == dest && d_fp == s_tp + 1 { "none" } else { "normal" };
+                let style = if src == dest && d_fp == s_tp + 1 {
+                    "dashed"
+                } else {
+                    "solid"
+                };
+                let arrow = if src == dest && d_fp == s_tp + 1 {
+                    "none"
+                } else {
+                    "normal"
+                };
                 let headport = if Node::is_end_node(dest) {
                     "w"
                 } else {


### PR DESCRIPTION
Operation hashes don't use the db_uuid so conflicts can arise between databases. This makes sure the hash starts with the db_uuid. I did not use this in the force_hash part...yet. May in the future.