### PR TITLE
Get dependencies from patch file if present

### DIFF
--- a/src/diffs/gfa.rs
+++ b/src/diffs/gfa.rs
@@ -226,7 +226,7 @@ fn links_from_blocks(node_blocks: &[NodeIntervalBlock]) -> Vec<Link> {
 }
 
 fn path_from_segments(sample_name: Option<&str>, path: &Path, segments: &[Segment]) -> GFAPath {
-    let path_name = if sample_name.unwrap_or("") != "" {
+    let path_name = if !sample_name.unwrap_or("").is_empty() {
         format!("{}.{}", sample_name.unwrap(), path.name)
     } else {
         path.name.clone()

--- a/src/operation_management.rs
+++ b/src/operation_management.rs
@@ -12,7 +12,7 @@ use crate::models::operations::{
 };
 use crate::models::path::Path;
 use crate::models::sample::Sample;
-use crate::models::sequence::Sequence;
+use crate::models::sequence::{NewSequence, Sequence};
 use crate::models::strand::Strand;
 use crate::models::traits::*;
 use fallible_streaming_iterator::FallibleStreamingIterator;
@@ -409,6 +409,9 @@ pub fn apply_changeset(
     changeset: &mut ChangesetIter,
     dependencies: &DependencyModels,
 ) {
+    for sequence in dependencies.sequences.iter() {
+        NewSequence::from(sequence).save(conn);
+    }
     for node in dependencies.nodes.iter() {
         if !Node::is_terminal(node.id) {
             assert!(Sequence::sequence_from_hash(conn, &node.sequence_hash).is_some());

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -3,8 +3,7 @@ use crate::models::operations::{FileAddition, Operation, OperationInfo, Operatio
 use crate::models::traits::Query;
 use crate::operation_management;
 use crate::operation_management::{
-    apply_changeset, end_operation, load_changeset, load_changeset_dependencies, start_operation,
-    OperationError,
+    apply_changeset, end_operation, start_operation, OperationError,
 };
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
@@ -82,10 +81,10 @@ where
 pub fn apply_patches(conn: &Connection, op_conn: &Connection, patches: &[OperationPatch]) {
     for patch in patches.iter() {
         let op_info = &patch.operation;
-        let changeset = load_changeset(op_info);
+        let changeset = &patch.changeset;
         let input: &mut dyn Read = &mut changeset.as_slice();
         let mut iter = ChangesetIter::start_strm(&input).unwrap();
-        let dependencies = load_changeset_dependencies(op_info);
+        let dependencies = serde_json::from_slice(&patch.dependencies).unwrap();
         let mut session = start_operation(conn);
         apply_changeset(conn, &mut iter, &dependencies);
         match end_operation(


### PR DESCRIPTION
These are stored in the patch file. It enables a patch to represent the complete history of a change.