### PR TITLE
GFA Export fixes

### DIFF
--- a/src/diffs/gfa.rs
+++ b/src/diffs/gfa.rs
@@ -164,7 +164,7 @@ pub fn gfa_sample_diff(
     let file = File::create(filename).unwrap();
     let mut writer = BufWriter::new(file);
     write_segments(&mut writer, &segments.iter().cloned().collect());
-    write_links(&mut writer, &links.iter().cloned().collect());
+    write_links(&mut writer, &links.iter().collect::<Vec<&Link>>());
 
     for path in paths {
         writer

--- a/src/gfa.rs
+++ b/src/gfa.rs
@@ -12,7 +12,7 @@ pub struct Segment {
     pub strand: Strand,
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Ord, PartialOrd)]
 pub struct Link {
     pub source_segment_id: String,
     pub source_strand: Strand,
@@ -38,7 +38,7 @@ impl Segment {
 
 fn segment_line(segment: &Segment) -> String {
     // NOTE: We encode the node ID and start coordinate in the segment ID
-    format!("S\t{}\t{}\t*\n", segment.segment_id(), segment.sequence)
+    format!("S\t{}\t{}\n", segment.segment_id(), segment.sequence)
 }
 
 fn link_line(link: &Link) -> String {
@@ -72,7 +72,7 @@ pub fn write_segments(writer: &mut BufWriter<File>, segments: &Vec<Segment>) {
     }
 }
 
-pub fn write_links(writer: &mut BufWriter<File>, links: &Vec<Link>) {
+pub fn write_links(writer: &mut BufWriter<File>, links: &[&Link]) {
     for link in links {
         writer
             .write_all(&link_line(link).into_bytes())

--- a/src/models/operations.rs
+++ b/src/models/operations.rs
@@ -988,7 +988,6 @@ mod tests {
         let db1_main = Branch::get_by_name(op_conn, db_uuid, "main").unwrap().id;
         let db2_main = Branch::get_by_name(op_conn, db_uuid2, "main").unwrap().id;
 
-        let change = FileAddition::create(op_conn, "foo", FileTypes::Fasta);
         let op_1 = Operation::create(op_conn, db_uuid, "vcf_addition", "op-1-hash").unwrap();
 
         assert_eq!(Branch::get_operations(op_conn, db2_main), vec![]);

--- a/src/operation_management.rs
+++ b/src/operation_management.rs
@@ -1202,7 +1202,7 @@ mod tests {
     use super::*;
     use crate::imports::fasta::import_fasta;
     use crate::models::file_types::FileTypes;
-    use crate::models::operations::{setup_db, Branch, FileAddition, Operation, OperationState};
+    use crate::models::operations::{setup_db, Branch, Operation, OperationState};
     use crate::models::{edge::Edge, metadata, node::Node, sample::Sample};
     use crate::test_helpers::{
         create_operation, get_connection, get_operation_connection, setup_block_group,

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -77,7 +77,6 @@ where
 
 pub fn apply_patches(conn: &Connection, op_conn: &Connection, patches: &[OperationPatch]) {
     for patch in patches.iter() {
-        let op_info = &patch.operation;
         let changeset = &patch.changeset;
         let input: &mut dyn Read = &mut changeset.as_slice();
         let mut iter = ChangesetIter::start_strm(&input).unwrap();


### PR DESCRIPTION
Fixes 2 problems w/ GFA export I hit:
* not all path links were exported
* the segment line id had a * at the end that was not in spec

The stuff in operations is just warning cleanup.