### PR TITLE
Add operation to derive chunks

### DIFF
--- a/src/graph_operators.rs
+++ b/src/graph_operators.rs
@@ -27,6 +27,8 @@ fn get_path(conn: &Connection, block_group_id: i64, backbone: Option<&str>) -> P
     }
 }
 
+// Given a specific chunk size, returns a list of ranges of that chunk size that cover the entire
+// path
 pub fn get_sized_ranges(
     conn: &Connection,
     collection_name: &str,
@@ -66,6 +68,8 @@ pub fn get_sized_ranges(
     chunk_ranges
 }
 
+// Given specific points on a path, returns a list of ranges that cover the entire path, broken up
+// by the input points
 pub fn get_breakpoint_ranges(
     conn: &Connection,
     collection_name: &str,

--- a/src/graph_operators.rs
+++ b/src/graph_operators.rs
@@ -382,6 +382,7 @@ mod tests {
         let mut fasta_update_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         fasta_update_path.push("fixtures/aa.fa");
 
+        setup_gen_dir();
         let conn = &get_connection(None);
         let db_uuid = metadata::get_db_uuid(conn);
         let op_conn = &get_operation_connection(None);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 #![allow(warnings)]
 use clap::{Parser, Subcommand};
+use core::ops::Range;
 use gen::config;
 use gen::config::{get_gen_dir, get_operation_connection};
 
@@ -9,7 +10,7 @@ use gen::exports::fasta::export_fasta;
 use gen::exports::genbank::export_genbank;
 use gen::exports::gfa::export_gfa;
 use gen::get_connection;
-use gen::graph_operators::derive_subgraph;
+use gen::graph_operators::{derive_chunks, get_breakpoint_ranges, get_sized_ranges};
 use gen::imports::fasta::{import_fasta, FastaError};
 use gen::imports::genbank::import_genbank;
 use gen::imports::gfa::{import_gfa, GFAImportError};
@@ -391,6 +392,33 @@ enum Commands {
         /// The name of the region to derive the subgraph from
         #[arg(short, long)]
         region: String,
+        /// Name of alternate path (not current) to use
+        #[arg(long)]
+        backbone: Option<String>,
+    },
+    /// Replace a sequence graph with subgraphs in the ranges of the specified coordinates
+    DeriveChunks {
+        /// The name of the collection to derive the subgraph from
+        #[arg(short, long)]
+        name: Option<String>,
+        /// The name of the parent sample
+        #[arg(short, long)]
+        sample: Option<String>,
+        /// The name of the new sample
+        #[arg(long)]
+        new_sample: String,
+        /// The name of the region to derive the subgraph from
+        #[arg(short, long)]
+        region: String,
+        /// Name of alternate path (not current) to use
+        #[arg(long)]
+        backbone: Option<String>,
+        /// Breakpoints to derive chunks from
+        #[arg(long)]
+        breakpoints: Option<String>,
+        /// The size of the chunks to derive
+        #[arg(long)]
+        chunk_size: Option<i64>,
     },
 }
 
@@ -1084,6 +1112,7 @@ fn main() {
             sample,
             new_sample,
             region,
+            backbone,
         }) => {
             conn.execute("BEGIN TRANSACTION", []).unwrap();
             operation_conn.execute("BEGIN TRANSACTION", []).unwrap();
@@ -1096,15 +1125,75 @@ fn main() {
             let interval = parsed_region.interval();
             let start_coordinate = interval.start().unwrap().get() as i64;
             let end_coordinate = interval.end().unwrap().get() as i64;
-            derive_subgraph(
+            derive_chunks(
                 &conn,
                 &operation_conn,
                 name,
                 sample_name.as_deref(),
                 &new_sample_name,
                 &parsed_region.name().to_string(),
-                start_coordinate,
-                end_coordinate,
+                backbone.as_deref(),
+                vec![Range {
+                    start: start_coordinate,
+                    end: end_coordinate,
+                }],
+            );
+            conn.execute("END TRANSACTION", []).unwrap();
+            operation_conn.execute("END TRANSACTION", []).unwrap();
+        }
+        Some(Commands::DeriveChunks {
+            name,
+            sample,
+            new_sample,
+            region,
+            backbone,
+            breakpoints,
+            chunk_size,
+        }) => {
+            conn.execute("BEGIN TRANSACTION", []).unwrap();
+            operation_conn.execute("BEGIN TRANSACTION", []).unwrap();
+            let name = &name
+                .clone()
+                .unwrap_or_else(|| get_default_collection(&operation_conn));
+            let sample_name = sample.clone();
+            let new_sample_name = new_sample.clone();
+            let parsed_region = region.parse::<Region>().unwrap();
+            let interval = parsed_region.interval();
+
+            let chunk_ranges;
+            if let Some(breakpoints) = breakpoints {
+                chunk_ranges = get_breakpoint_ranges(
+                    &conn,
+                    name,
+                    sample_name.as_deref(),
+                    &new_sample_name,
+                    &parsed_region.name().to_string(),
+                    backbone.as_deref(),
+                    breakpoints,
+                );
+            } else if let Some(chunk_size) = chunk_size {
+                chunk_ranges = get_sized_ranges(
+                    &conn,
+                    name,
+                    sample_name.as_deref(),
+                    &new_sample_name,
+                    &parsed_region.name().to_string(),
+                    backbone.as_deref(),
+                    *chunk_size,
+                );
+            } else {
+                panic!("No chunking method specified.");
+            }
+
+            derive_chunks(
+                &conn,
+                &operation_conn,
+                name,
+                sample_name.as_deref(),
+                &new_sample_name,
+                &parsed_region.name().to_string(),
+                backbone.as_deref(),
+                chunk_ranges,
             );
             conn.execute("END TRANSACTION", []).unwrap();
             operation_conn.execute("END TRANSACTION", []).unwrap();

--- a/src/models/block_group.rs
+++ b/src/models/block_group.rs
@@ -800,6 +800,26 @@ impl BlockGroup {
         paths[0].clone()
     }
 
+    pub fn get_path_by_name(
+        conn: &Connection,
+        block_group_id: i64,
+        path_name: &str,
+    ) -> Option<Path> {
+        let paths = Path::query(
+            conn,
+            "SELECT * FROM paths WHERE block_group_id = ?1 ORDER BY id DESC",
+            rusqlite::params!(SQLValue::from(block_group_id)),
+        );
+
+        for path in &paths {
+            if path.name == path_name {
+                return Some(path.clone());
+            }
+        }
+
+        None
+    }
+
     pub fn derive_subgraph(
         conn: &Connection,
         source_block_group_id: i64,
@@ -871,7 +891,7 @@ impl BlockGroup {
         let new_start_edge = Edge::create(
             conn,
             PATH_START_NODE_ID,
-            -1,
+            0,
             Strand::Forward,
             start_block.node_id,
             start_node_coordinate,
@@ -889,7 +909,7 @@ impl BlockGroup {
             end_node_coordinate,
             end_block.strand,
             PATH_END_NODE_ID,
-            -1,
+            0,
             Strand::Forward,
         );
         let new_end_edge_data = BlockGroupEdgeData {


### PR DESCRIPTION
Example usage:

```
cargo run -- init
cargo run -- import --fasta fixtures/simple.fa
# Create two example integration points
cargo run -- update --fasta fixtures/aa.fa --start 3 --end 5 --region-name m123 --new-sample test1
cargo run -- update --fasta fixtures/aa.fa --start 15 --end 20 --region-name m123 --sample test1 --new-sample test2
# Derive chunks with breakpoints in between the edits
cargo run -- derive-chunks --new-sample splits --region m123 --breakpoints 1,8,25 --sample test2
# View one of the new chunks
cargo run -- view -s splits m123.2
```