### PR TITLE
Check if position is beyond path length

### DIFF
--- a/fixtures/vcfs/out_of_bounds.vcf
+++ b/fixtures/vcfs/out_of_bounds.vcf
@@ -1,0 +1,10 @@
+##fileformat=VCFv4.1
+##filedate=Tue Sep  4 13:12:57 2018
+##reference=simple.fa
+##contig=<ID=m123,length=34>
+##filter="QUAL > 1"
+##FILTER=<ID=PASS,Description="All filters passed">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	invalid
+m123	3	.	CGA	CA	1611.92	.	.	GT	1/1
+m123	100	.	TC	TAGA	2216.6	.	.	GT	1/1

--- a/src/exports/gfa.rs
+++ b/src/exports/gfa.rs
@@ -468,7 +468,7 @@ mod tests {
             phased: 0,
         };
         let tree = path.intervaltree(conn);
-        BlockGroup::insert_change(conn, &change, &tree);
+        BlockGroup::insert_change(conn, &change, &tree).unwrap();
 
         let augmented_edges = BlockGroupEdge::edges_for_block_group(conn, block_group_id);
         let mut node_ids = HashSet::new();

--- a/src/imports/genbank.rs
+++ b/src/imports/genbank.rs
@@ -171,7 +171,7 @@ where
                         },
                     };
                     let tree = path.intervaltree(conn);
-                    BlockGroup::insert_change(conn, &change, &tree);
+                    BlockGroup::insert_change(conn, &change, &tree).unwrap();
                 }
             }
             Err(e) => return Err(GenBankError::ParseError(format!("Failed to parse {}", e))),

--- a/src/models/block_group.rs
+++ b/src/models/block_group.rs
@@ -658,7 +658,13 @@ impl BlockGroup {
             start_blocks[0]
         };
 
-        if Node::is_terminal(start_block.node_id) {
+        // Ensure the change is within the path bounds. The logic here is a bit backwards, where
+        // we check if the start is before the start block's end and the end is before the end
+        // block's start. This is because the terminal blocks start and end at the bounds of the
+        // interval tree. So while it's ok to have a start/end block be the start/end block (for
+        // changes at the extremes, it's not ok for the change to start beyond the current
+        // boundaries.
+        if Node::is_start_node(start_block.node_id) && change.start < start_block.end {
             panic!("Invalid change specified. Coordinate is outside bounds of path range.");
         }
 
@@ -667,7 +673,7 @@ impl BlockGroup {
         assert_eq!(end_blocks.len(), 1);
         let end_block = end_blocks[0];
 
-        if Node::is_terminal(end_block.node_id) {
+        if Node::is_end_node(end_block.node_id) && change.end > end_block.start {
             panic!("Invalid change specified. Coordinate is outside bounds of path range.");
         }
 

--- a/src/models/block_group.rs
+++ b/src/models/block_group.rs
@@ -14,7 +14,7 @@ use crate::graph::{
 use crate::models::accession::{Accession, AccessionEdge, AccessionEdgeData, AccessionPath};
 use crate::models::block_group_edge::{AugmentedEdgeData, BlockGroupEdge, BlockGroupEdgeData};
 use crate::models::edge::{Edge, EdgeData, GroupBlock};
-use crate::models::node::{PATH_END_NODE_ID, PATH_START_NODE_ID};
+use crate::models::node::{Node, PATH_END_NODE_ID, PATH_START_NODE_ID};
 use crate::models::path::{Path, PathBlock, PathData};
 use crate::models::path_edge::PathEdge;
 use crate::models::strand::Strand;
@@ -658,10 +658,18 @@ impl BlockGroup {
             start_blocks[0]
         };
 
+        if Node::is_terminal(start_block.node_id) {
+            panic!("Invalid change specified. Coordinate is outside bounds of path range.");
+        }
+
         let end_blocks: Vec<&NodeIntervalBlock> =
             tree.query_point(change.end).map(|x| &x.value).collect();
         assert_eq!(end_blocks.len(), 1);
         let end_block = end_blocks[0];
+
+        if Node::is_terminal(end_block.node_id) {
+            panic!("Invalid change specified. Coordinate is outside bounds of path range.");
+        }
 
         let mut new_edges = vec![];
 

--- a/src/models/block_group.rs
+++ b/src/models/block_group.rs
@@ -13,7 +13,6 @@ use crate::models::path::{Path, PathBlock, PathData};
 use crate::models::path_edge::PathEdge;
 use crate::models::strand::Strand;
 use crate::models::traits::*;
-use crate::operation_management::OperationError;
 use intervaltree::IntervalTree;
 use petgraph::graphmap::DiGraphMap;
 use petgraph::Direction;
@@ -1019,7 +1018,7 @@ mod tests {
             phased: 0,
         };
         let tree = path.intervaltree(&conn);
-        BlockGroup::insert_change(&conn, &change, &tree);
+        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, block_group_id, false);
         assert_eq!(
@@ -1058,7 +1057,7 @@ mod tests {
         };
         // take out an entire block.
         let tree = path.intervaltree(&conn);
-        BlockGroup::insert_change(&conn, &change, &tree);
+        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
         let all_sequences = BlockGroup::get_all_sequences(&conn, block_group_id, false);
         assert_eq!(
             all_sequences,
@@ -1101,7 +1100,7 @@ mod tests {
             phased: 0,
         };
         let tree = path.intervaltree(&conn);
-        BlockGroup::insert_change(&conn, &change, &tree);
+        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, block_group_id, false);
         assert_eq!(
@@ -1143,7 +1142,7 @@ mod tests {
             phased: 0,
         };
         let tree = path.intervaltree(&conn);
-        BlockGroup::insert_change(&conn, &change, &tree);
+        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, block_group_id, false);
         assert_eq!(
@@ -1185,7 +1184,7 @@ mod tests {
             phased: 0,
         };
         let tree = path.intervaltree(&conn);
-        BlockGroup::insert_change(&conn, &change, &tree);
+        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, block_group_id, false);
         assert_eq!(
@@ -1227,7 +1226,7 @@ mod tests {
             phased: 0,
         };
         let tree = path.intervaltree(&conn);
-        BlockGroup::insert_change(&conn, &change, &tree);
+        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, block_group_id, false);
         assert_eq!(
@@ -1269,7 +1268,7 @@ mod tests {
             phased: 0,
         };
         let tree = path.intervaltree(&conn);
-        BlockGroup::insert_change(&conn, &change, &tree);
+        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, block_group_id, false);
         assert_eq!(
@@ -1311,7 +1310,7 @@ mod tests {
             phased: 0,
         };
         let tree = path.intervaltree(&conn);
-        BlockGroup::insert_change(&conn, &change, &tree);
+        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, block_group_id, false);
         assert_eq!(
@@ -1353,7 +1352,7 @@ mod tests {
             phased: 0,
         };
         let tree = path.intervaltree(&conn);
-        BlockGroup::insert_change(&conn, &change, &tree);
+        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, block_group_id, false);
         assert_eq!(
@@ -1395,7 +1394,7 @@ mod tests {
             phased: 0,
         };
         let tree = path.intervaltree(&conn);
-        BlockGroup::insert_change(&conn, &change, &tree);
+        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, block_group_id, false);
         assert_eq!(
@@ -1440,7 +1439,7 @@ mod tests {
 
         // take out an entire block.
         let tree = path.intervaltree(&conn);
-        BlockGroup::insert_change(&conn, &change, &tree);
+        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
         let all_sequences = BlockGroup::get_all_sequences(&conn, block_group_id, false);
         assert_eq!(
             all_sequences,
@@ -1481,7 +1480,7 @@ mod tests {
             phased: 0,
         };
         let tree = path.intervaltree(&conn);
-        BlockGroup::insert_change(&conn, &change, &tree);
+        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, block_group_id, false);
         assert_eq!(
@@ -1493,7 +1492,7 @@ mod tests {
         );
 
         let tree = path.intervaltree(&conn);
-        BlockGroup::insert_change(&conn, &change, &tree);
+        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, block_group_id, false);
         assert_eq!(
@@ -1535,7 +1534,7 @@ mod tests {
             phased: 0,
         };
         let tree = path.intervaltree(&conn);
-        BlockGroup::insert_change(&conn, &change, &tree);
+        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, block_group_id, false);
         assert_eq!(
@@ -1578,7 +1577,7 @@ mod tests {
             phased: 0,
         };
         let tree = path.intervaltree(&conn);
-        BlockGroup::insert_change(&conn, &change, &tree);
+        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, block_group_id, false);
         assert_eq!(
@@ -1620,7 +1619,7 @@ mod tests {
             phased: 0,
         };
         let tree = path.intervaltree(&conn);
-        BlockGroup::insert_change(&conn, &change, &tree);
+        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, block_group_id, false);
         assert_eq!(
@@ -1662,7 +1661,7 @@ mod tests {
             phased: 0,
         };
         let tree = path.intervaltree(&conn);
-        BlockGroup::insert_change(&conn, &change, &tree);
+        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, block_group_id, false);
         assert_eq!(
@@ -1704,7 +1703,7 @@ mod tests {
             phased: 0,
         };
         let tree = path.intervaltree(&conn);
-        BlockGroup::insert_change(&conn, &change, &tree);
+        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, block_group_id, false);
         assert_eq!(
@@ -1746,7 +1745,7 @@ mod tests {
             phased: 0,
         };
         let tree = path.intervaltree(&conn);
-        BlockGroup::insert_change(&conn, &change, &tree);
+        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, block_group_id, false);
         assert_eq!(
@@ -1834,7 +1833,7 @@ mod tests {
             phased: 0,
         };
         let tree = path.intervaltree(&conn);
-        BlockGroup::insert_change(&conn, &change, &tree);
+        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, block_group_id, false);
         assert_eq!(
@@ -1876,7 +1875,7 @@ mod tests {
             phased: 0,
         };
         let tree = path.intervaltree(&conn);
-        BlockGroup::insert_change(&conn, &change, &tree);
+        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
 
         let all_sequences = BlockGroup::get_all_sequences(&conn, block_group_id, false);
         assert_eq!(
@@ -1927,7 +1926,7 @@ mod tests {
             phased: 0,
         };
         let tree = path.intervaltree(conn);
-        BlockGroup::insert_change(conn, &change, &tree);
+        BlockGroup::insert_change(conn, &change, &tree).unwrap();
 
         let tree = BlockGroup::intervaltree_for(conn, block_group_id, false);
         let tree2 = BlockGroup::intervaltree_for(conn, block_group_id, true);
@@ -2106,7 +2105,7 @@ mod tests {
         };
         // note we are making our change against the new blockgroup, and not the parent blockgroup
         let tree = BlockGroup::intervaltree_for(conn, new_bg_id, true);
-        BlockGroup::insert_change(conn, &change, &tree);
+        BlockGroup::insert_change(conn, &change, &tree).unwrap();
         let all_sequences = BlockGroup::get_all_sequences(conn, new_bg_id, true);
         assert_eq!(
             all_sequences,
@@ -2151,7 +2150,7 @@ mod tests {
         };
         // take out an entire block.
         let tree = BlockGroup::intervaltree_for(conn, gc_bg_id, true);
-        BlockGroup::insert_change(conn, &change, &tree);
+        BlockGroup::insert_change(conn, &change, &tree).unwrap();
         let all_sequences = BlockGroup::get_all_sequences(conn, gc_bg_id, true);
         assert_eq!(
             all_sequences,
@@ -2201,7 +2200,7 @@ mod tests {
         };
         // note we are making our change against the new blockgroup, and not the parent blockgroup
         let tree = BlockGroup::intervaltree_for(conn, new_bg_id, true);
-        BlockGroup::insert_change(conn, &change, &tree);
+        BlockGroup::insert_change(conn, &change, &tree).unwrap();
         let all_sequences = BlockGroup::get_all_sequences(conn, new_bg_id, true);
         assert_eq!(
             all_sequences,
@@ -2256,7 +2255,7 @@ mod tests {
         };
         // take out an entire block.
         let tree = BlockGroup::intervaltree_for(conn, gc_bg_id, true);
-        BlockGroup::insert_change(conn, &change, &tree);
+        BlockGroup::insert_change(conn, &change, &tree).unwrap();
         let all_sequences = BlockGroup::get_all_sequences(conn, gc_bg_id, true);
         assert_eq!(
             all_sequences,
@@ -2313,7 +2312,7 @@ mod tests {
         };
         // note we are making our change against the new blockgroup, and not the parent blockgroup
         let tree = BlockGroup::intervaltree_for(conn, new_bg_id, true);
-        BlockGroup::insert_change(conn, &change, &tree);
+        BlockGroup::insert_change(conn, &change, &tree).unwrap();
         let all_sequences = BlockGroup::get_all_sequences(conn, new_bg_id, true);
         assert_eq!(
             all_sequences,
@@ -2368,7 +2367,7 @@ mod tests {
         };
         // take out an entire block.
         let tree = BlockGroup::intervaltree_for(conn, gc_bg_id, true);
-        BlockGroup::insert_change(conn, &change, &tree);
+        BlockGroup::insert_change(conn, &change, &tree).unwrap();
     }
 
     mod test_derive_subgraph {

--- a/src/models/edge.rs
+++ b/src/models/edge.rs
@@ -762,7 +762,7 @@ mod tests {
             phased: 0,
         };
         let tree = path.intervaltree(&conn);
-        BlockGroup::insert_change(&conn, &change, &tree);
+        BlockGroup::insert_change(&conn, &change, &tree).unwrap();
         let mut edges = BlockGroupEdge::edges_for_block_group(&conn, block_group_id);
 
         let blocks = Edge::blocks_from_edges(&conn, &edges);

--- a/src/models/path.rs
+++ b/src/models/path.rs
@@ -262,6 +262,13 @@ impl Path {
             .join("")
     }
 
+    pub fn length(&self, conn: &Connection) -> i64 {
+        let blocks = self.blocks(conn);
+        let end_block = blocks.last().unwrap();
+        // the last block is the terminal node, which starts at the end of the path
+        end_block.path_start
+    }
+
     pub fn edge_pairs_to_block(
         &self,
         block_id: i64,

--- a/src/updates/fasta.rs
+++ b/src/updates/fasta.rs
@@ -104,7 +104,7 @@ pub fn update_with_fasta(
     };
 
     let interval_tree = path.intervaltree(conn);
-    BlockGroup::insert_change(conn, &path_change, &interval_tree);
+    BlockGroup::insert_change(conn, &path_change, &interval_tree).unwrap();
 
     let edge_to_new_node = Edge::query(
         conn,

--- a/src/updates/genbank.rs
+++ b/src/updates/genbank.rs
@@ -180,7 +180,7 @@ where
                         },
                     };
                     let tree = path.intervaltree(conn);
-                    BlockGroup::insert_change(conn, &change, &tree);
+                    BlockGroup::insert_change(conn, &change, &tree).unwrap();
                 }
             }
             Err(e) => return Err(GenBankError::ParseError(format!("Failed to parse {}", e))),

--- a/src/updates/vcf.rs
+++ b/src/updates/vcf.rs
@@ -293,13 +293,9 @@ pub fn update_with_vcf<'a>(
                         };
                         let sample_path =
                             PathCache::lookup(&mut path_cache, sample_bg_id, seq_name.clone());
-                        let path_length = if let Some(l) = path_lengths.get(&sample_path.id) {
-                            l
-                        } else {
-                            let l = sample_path.length(conn);
-                            path_lengths.insert(sample_path.id, l);
-                            &path_lengths[&sample_path.id]
-                        };
+                        let path_length = path_lengths
+                            .entry(sample_path.id)
+                            .or_insert(sample_path.length(conn));
 
                         if ref_start > *path_length {
                             return Err(VcfError::InvalidRecord(format!("Invalid position found. Path {0} has length of {path_length}, change is in position {ref_start}.", sample_path.name)));

--- a/src/updates/vcf.rs
+++ b/src/updates/vcf.rs
@@ -294,8 +294,8 @@ pub fn update_with_vcf<'a>(
                         let path_length = if let Some(l) = path_lengths.get(&sample_path.id) {
                             l
                         } else {
-                            let l = sample_path.sequence(conn).len();
-                            path_lengths.insert(sample_path.id, l as i64);
+                            let l = sample_path.length(conn);
+                            path_lengths.insert(sample_path.id, l);
                             &path_lengths[&sample_path.id]
                         };
 

--- a/src/updates/vcf.rs
+++ b/src/updates/vcf.rs
@@ -498,7 +498,8 @@ pub fn update_with_vcf<'a>(
             &path_changes,
             &mut path_cache,
             coordinate_frame.is_some(),
-        );
+        )
+        .unwrap();
         bar.inc(path_changes.len() as u64);
         summary
             .entry(sample_name)


### PR DESCRIPTION
Found this problem when i applied a vcf to the wrong fasta. This ensures we aren't making changes outside the scope of the interval tree. I put it in setup_up_new_edges as a general catch area, but also in the vcf update code where i initially found the bug so it can bail early before parsing a few gigs of vcf.