### PR TITLE
Viewer - handle synchronization to external changes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -589,11 +589,9 @@ fn main() {
             collection,
             position,
         }) => {
-            conn.execute("BEGIN TRANSACTION", []).unwrap();
             let collection_name = &collection
                 .clone()
                 .unwrap_or_else(|| get_default_collection(&operation_conn));
-            conn.execute("END TRANSACTION", []).unwrap();
 
             // view_block_group is a long-running operation that manages its own transactions
             view_block_group(

--- a/src/main.rs
+++ b/src/main.rs
@@ -593,7 +593,9 @@ fn main() {
             let collection_name = &collection
                 .clone()
                 .unwrap_or_else(|| get_default_collection(&operation_conn));
+            conn.execute("END TRANSACTION", []).unwrap();
 
+            // view_block_group is a long-running operation that manages its own transactions
             view_block_group(
                 &conn,
                 graph,
@@ -601,7 +603,6 @@ fn main() {
                 collection_name,
                 position.clone(),
             );
-            conn.execute("END TRANSACTION", []).unwrap();
         }
         Some(Commands::Update {
             name,


### PR DESCRIPTION
In the final commit to my previous PR I had added a connection refreshing routine that opened and closed the db connection. That was overkill and by using Connection::open instead of get_connection it introduced a new bug (Connection::open does not load he extensions that other methods rely on). Now we're not changing the conn at all.